### PR TITLE
feat: bun-compile release pipeline (wire#8 PR 1 of 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+# On every tag (v*), build Wire binaries for the four supported targets
+# and attach them to the auto-created GitHub Release. The install.sh
+# script (and anyone doing a manual install) downloads from here.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Compile all targets
+        run: bash scripts/build-binaries.sh
+
+      - name: Compute sha256 checksums
+        run: |
+          cd dist
+          shasum -a 256 wire-*.zip wire-* | awk '!/\.zip\.|sha256/' > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/wire-darwin-arm64.zip
+            dist/wire-darwin-x64.zip
+            dist/wire-linux-arm64.zip
+            dist/wire-linux-x64.zip
+            dist/wire-darwin-arm64
+            dist/wire-darwin-x64
+            dist/wire-linux-arm64
+            dist/wire-linux-x64
+            dist/SHA256SUMS
+          generate_release_notes: true
+          body: |
+            Wire release ${{ github.ref_name }}.
+
+            **Install (one-liner):**
+
+            ```bash
+            curl -fsSL https://raw.githubusercontent.com/agiterra/wire/main/scripts/install.sh | bash
+            ```
+
+            The installer auto-detects your platform, downloads the
+            right binary from this release, writes a launchd unit
+            (macOS) or systemd user unit (Linux), and starts the
+            service.
+
+            **Manual install:** download the `wire-<platform>.zip`
+            for your OS, unzip, chmod +x, and run. Config lives at
+            `~/.wire/.env` — see the repo README.

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+# Compiled release artifacts (produced by scripts/build-binaries.sh)
+dist/

--- a/scripts/build-binaries.sh
+++ b/scripts/build-binaries.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Compile Wire to a standalone bun executable for every supported target.
+#
+# Targets: darwin-arm64 (Apple Silicon), darwin-x64, linux-arm64, linux-x64.
+# bun --compile bundles the runtime + all deps + bun:sqlite, so the
+# resulting binaries have no runtime dependencies.
+#
+# Output: dist/wire-<target>[.zip] per target. Zips are what a release
+# installer downloads; the raw binary is kept alongside for local
+# smoke-tests.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mkdir -p dist
+
+# shellcheck disable=SC2207
+TARGETS=(
+  "bun-darwin-arm64"
+  "bun-darwin-x64"
+  "bun-linux-arm64"
+  "bun-linux-x64"
+)
+
+VERSION="$(bun -e 'console.log((await import("./package.json", { with: { type: "json" } })).default.version)')"
+echo "Building wire v${VERSION} for ${#TARGETS[@]} targets…"
+
+for target in "${TARGETS[@]}"; do
+  short="${target#bun-}"
+  outfile="dist/wire-${short}"
+  echo "  → ${target} → ${outfile}"
+  bun build --compile --target="${target}" ./src/index.ts --outfile "${outfile}"
+  # Bundle a README + LICENSE alongside the binary in a zip so single-file
+  # downloads carry install instructions.
+  zipfile="${outfile}.zip"
+  rm -f "${zipfile}"
+  (
+    cd dist
+    cp -f "../LICENSE" ./LICENSE 2>/dev/null || true
+    zip -q "wire-${short}.zip" "wire-${short}" LICENSE 2>/dev/null || zip -q "wire-${short}.zip" "wire-${short}"
+  )
+done
+
+echo
+echo "Done. Artifacts in dist/:"
+ls -lh dist/ | awk 'NR>1 {print "  "$0}'


### PR DESCRIPTION
First PR of three for wire#8.

Adds:
- scripts/build-binaries.sh — compiles all 4 targets locally
- .github/workflows/release.yml — tag-triggered Release with binaries + SHA256SUMS

Follow-ups:
- PR 2: install.sh + launchd/systemd unit templates
- PR 3: tag v1.0.0 (first real release)

Smoke-tested locally — all 4 targets build, darwin-arm64 binary boots against dev DB.