### PR TITLE
release: wire v1.0.0 (wire#8 PR 3 of 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "0.11.0",
+  "version": "1.0.0",
   "description": "The Wire — persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Third and final PR for wire#8. Bumps to 1.0.0 and cuts the first real release — tag push after merge fires the release.yml workflow and produces downloadable binaries.