### PR TITLE
feat: federation foundation (peers + server identity + wire peer CLI); v1.1.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "1.0.0",
+  "version": "1.1.0-alpha.1",
   "description": "The Wire — persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,121 @@
+/**
+ * Wire CLI dispatcher.
+ *
+ * The `wire` binary is multi-purpose:
+ *   wire                           Start the server (default).
+ *   wire serve                     Explicit server mode.
+ *   wire version                   Print version.
+ *   wire peer pubkey               Print this server's Ed25519 pubkey (base64).
+ *   wire peer add <name> <url> <pubkey> [--notes "..."]
+ *   wire peer list
+ *   wire peer remove <name>
+ *   wire peer update-url <name> <url>
+ *
+ * All `peer` subcommands operate directly on the local store — they
+ * don't need the server running.
+ */
+
+import { Store } from "./store.js";
+import { getServerPubkey } from "./identity.js";
+import pkg from "../package.json" with { type: "json" };
+
+const USAGE = `Wire ${pkg.version}
+
+Usage:
+  wire                                      Start the server.
+  wire serve                                Start the server (explicit).
+  wire version                              Print version.
+
+  wire peer pubkey                          Print this server's pubkey.
+  wire peer add <name> <url> <pubkey>       Register a peer.
+      [--notes "free-form text"]
+  wire peer list                            List registered peers.
+  wire peer remove <name>                   Forget a peer.
+  wire peer update-url <name> <url>         Re-point a peer (e.g. ngrok rotated).
+
+Peers are paired out-of-band. To add each other:
+  1. On each machine: wire peer pubkey       -> exchange the two pubkeys.
+  2. On each machine: wire peer add <remote-alias> <remote-url> <remote-pubkey>
+`;
+
+type CliResult = { exit: number; stdout?: string; stderr?: string };
+
+function parseFlags(args: string[]): { flags: Record<string, string>; positional: string[] } {
+  const flags: Record<string, string> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a.startsWith("--")) {
+      flags[a.slice(2)] = args[i + 1] ?? "";
+      i++;
+    } else {
+      positional.push(a);
+    }
+  }
+  return { flags, positional };
+}
+
+export async function runCli(argv: string[]): Promise<CliResult> {
+  const [cmd, ...rest] = argv;
+
+  // Default + explicit serve are handled by the caller (src/index.ts) so
+  // we can keep the server startup synchronous and avoid a double
+  // deps graph. The CLI only handles non-serve commands.
+  if (!cmd || cmd === "serve") {
+    return { exit: -1 }; // sentinel: caller should start the server
+  }
+  if (cmd === "-h" || cmd === "--help") return { exit: 0, stdout: USAGE };
+  if (cmd === "version" || cmd === "--version") return { exit: 0, stdout: `${pkg.version}\n` };
+
+  if (cmd === "peer") {
+    return runPeerCli(rest);
+  }
+  return { exit: 1, stderr: `unknown command: ${cmd}\n\n${USAGE}` };
+}
+
+async function runPeerCli(args: string[]): Promise<CliResult> {
+  const [sub, ...rest] = args;
+  if (!sub) return { exit: 1, stderr: `peer: subcommand required\n\n${USAGE}` };
+
+  if (sub === "pubkey") {
+    const pubkey = await getServerPubkey();
+    return { exit: 0, stdout: `${pubkey}\n` };
+  }
+
+  // Remaining subcommands touch the store. Open it lazily.
+  const store = new Store();
+  try {
+    switch (sub) {
+      case "add": {
+        const { flags, positional } = parseFlags(rest);
+        const [name, url, pubkey] = positional;
+        if (!name || !url || !pubkey) {
+          return { exit: 1, stderr: "peer add: requires <name> <url> <pubkey>\n" };
+        }
+        if (store.getPeer(name)) return { exit: 1, stderr: `peer '${name}' already registered\n` };
+        const peer = store.createPeer({ name, base_url: url, pubkey, notes: flags.notes });
+        return { exit: 0, stdout: `${JSON.stringify(peer)}\n` };
+      }
+      case "list":
+        return { exit: 0, stdout: `${JSON.stringify(store.listPeers(), null, 2)}\n` };
+      case "remove": {
+        const [name] = rest;
+        if (!name) return { exit: 1, stderr: "peer remove: requires <name>\n" };
+        if (!store.getPeer(name)) return { exit: 1, stderr: `peer '${name}' not found\n` };
+        store.deletePeer(name);
+        return { exit: 0, stdout: `${JSON.stringify({ removed: name })}\n` };
+      }
+      case "update-url": {
+        const [name, url] = rest;
+        if (!name || !url) return { exit: 1, stderr: "peer update-url: requires <name> <url>\n" };
+        if (!store.getPeer(name)) return { exit: 1, stderr: `peer '${name}' not found\n` };
+        store.updatePeerUrl(name, url);
+        return { exit: 0, stdout: `${JSON.stringify(store.getPeer(name))}\n` };
+      }
+      default:
+        return { exit: 1, stderr: `peer: unknown subcommand '${sub}'\n\n${USAGE}` };
+    }
+  } finally {
+    store.close();
+  }
+}

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,0 +1,77 @@
+/**
+ * Wire server identity — Ed25519 keypair at ${WIRE_HOME}/server.key.
+ *
+ * Used for peer-to-peer federation: each Wire signs outgoing
+ * peer-forwarded messages with this key, and peers verify against
+ * the pubkey they registered for that peer.
+ *
+ * Storage format: a JSON file containing base64-encoded PKCS8 private
+ * key + base64 raw pubkey. Auto-generated on first boot; persisted
+ * across restarts.
+ */
+
+import { join } from "path";
+import { homedir } from "os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "fs";
+
+export type ServerIdentity = {
+  privateKey: CryptoKey;
+  privateKeyB64: string;  // base64 PKCS8, for persisting to disk
+  pubkeyB64: string;      // base64 raw, published to peers
+};
+
+type OnDisk = {
+  privateKeyB64: string;
+  pubkeyB64: string;
+  createdAt: number;
+};
+
+function defaultKeyPath(): string {
+  const home = process.env.WIRE_HOME ?? join(process.env.HOME ?? homedir(), ".wire");
+  return join(home, "server.key");
+}
+
+async function derivePubkeyB64(privateKey: CryptoKey): Promise<string> {
+  const jwk = await crypto.subtle.exportKey("jwk", privateKey);
+  // Ed25519 jwk has `x` as the raw pubkey (base64url). Convert to std base64.
+  const base64url = jwk.x ?? "";
+  return base64url.replace(/-/g, "+").replace(/_/g, "/") + "==".slice(0, (4 - base64url.length % 4) % 4);
+}
+
+async function exportPrivateKeyB64(privateKey: CryptoKey): Promise<string> {
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", privateKey);
+  return Buffer.from(pkcs8).toString("base64");
+}
+
+async function importPrivateKeyB64(b64: string): Promise<CryptoKey> {
+  const pkcs8 = Buffer.from(b64, "base64");
+  return crypto.subtle.importKey("pkcs8", pkcs8, { name: "Ed25519" }, true, ["sign"]);
+}
+
+/**
+ * Load the server identity from disk, generating one on first boot.
+ * File permissions are set to 0600 — the private key never leaves
+ * the local machine.
+ */
+export async function loadOrCreateServerIdentity(keyPath: string = defaultKeyPath()): Promise<ServerIdentity> {
+  if (existsSync(keyPath)) {
+    const raw = JSON.parse(readFileSync(keyPath, "utf8")) as OnDisk;
+    const privateKey = await importPrivateKeyB64(raw.privateKeyB64);
+    return { privateKey, privateKeyB64: raw.privateKeyB64, pubkeyB64: raw.pubkeyB64 };
+  }
+  // First-boot generation.
+  mkdirSync(keyPath.replace(/\/[^/]+$/, ""), { recursive: true });
+  const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, true, ["sign", "verify"]) as CryptoKeyPair;
+  const privateKeyB64 = await exportPrivateKeyB64(keyPair.privateKey);
+  const pubkeyB64 = await derivePubkeyB64(keyPair.privateKey);
+  const payload: OnDisk = { privateKeyB64, pubkeyB64, createdAt: Date.now() };
+  writeFileSync(keyPath, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  try { chmodSync(keyPath, 0o600); } catch { /* best-effort */ }
+  return { privateKey: keyPair.privateKey, privateKeyB64, pubkeyB64 };
+}
+
+/** Read just the pubkey, generating a fresh identity if none exists. */
+export async function getServerPubkey(keyPath?: string): Promise<string> {
+  const id = await loadOrCreateServerIdentity(keyPath);
+  return id.pubkeyB64;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,19 @@ import { Router } from "./router.js";
 import { MessageEmitter } from "./emitter.js";
 import { createServer, runCleanup } from "./server.js";
 import { HeartbeatScheduler } from "./heartbeat.js";
+import { runCli } from "./cli.js";
+import { loadOrCreateServerIdentity } from "./identity.js";
+
+// CLI dispatch. Non-serve commands (peer add/list/remove/update-url,
+// version, pubkey) exit here without starting the server. The -1
+// sentinel means "continue into the normal server startup below."
+const cliArgv = process.argv.slice(2);
+const cliResult = await runCli(cliArgv);
+if (cliResult.exit !== -1) {
+  if (cliResult.stdout) process.stdout.write(cliResult.stdout);
+  if (cliResult.stderr) process.stderr.write(cliResult.stderr);
+  process.exit(cliResult.exit);
+}
 
 const port = parseInt(process.env.WIRE_PORT ?? "9800", 10);
 const dbPath = process.env.WIRE_DB ?? `${process.env.HOME}/.wire/wire.db`;
@@ -41,6 +54,12 @@ const store = new Store(dbPath);
 const emitter = new MessageEmitter();
 const router = new Router(store, emitter, log);
 const heartbeats = new HeartbeatScheduler(store, router, log);
+
+// Server identity — Ed25519 keypair for peer-to-peer federation (v1.1.0).
+// Generated on first boot; pubkey is what you paste when peering.
+const serverIdentity = await loadOrCreateServerIdentity();
+log.info({ event: "server_identity", pubkey: serverIdentity.pubkeyB64 }, "server identity loaded");
+
 const server = createServer({ port, store, router, emitter, log, heartbeats });
 heartbeats.start();
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -137,6 +137,22 @@ CREATE TABLE IF NOT EXISTS operator_sessions (
     expires_at      INTEGER NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_operator_sessions_operator ON operator_sessions(operator_id);
+
+-- Peers table (v1.1.0 federation). Each Wire keeps a local list of
+-- peer instances it knows how to forward messages to. There is no
+-- central registry — pair peers by running 'wire peer add' on both
+-- sides with the other's base_url + server pubkey (output of
+-- 'wire peer pubkey'). Pubkeys are stable; base_url may rotate when
+-- ngrok tunnels restart (update via 'wire peer update-url').
+CREATE TABLE IF NOT EXISTS peers (
+    name            TEXT PRIMARY KEY,        -- user alias ('home-mini')
+    base_url        TEXT NOT NULL,           -- 'https://random.ngrok.app'
+    pubkey          TEXT NOT NULL,           -- base64 Ed25519 pubkey of the peer Wire
+    added_at        INTEGER NOT NULL,
+    last_seen       INTEGER,
+    notes           TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_peers_pubkey ON peers(pubkey);
 `;
 
 export type Message = {
@@ -202,6 +218,15 @@ export type Heartbeat = {
   active: number;
   last_fired: number | null;
   created_at: number;
+};
+
+export type Peer = {
+  name: string;
+  base_url: string;
+  pubkey: string;
+  added_at: number;
+  last_seen: number | null;
+  notes: string | null;
 };
 
 export class Store {
@@ -811,6 +836,47 @@ export class Store {
 
   deleteHeartbeatsForAgent(agentId: string): void {
     this.db.prepare("DELETE FROM heartbeats WHERE agent_id = ?").run(agentId);
+  }
+
+  // --- Peers (v1.1.0 federation) ---
+
+  createPeer(opts: { name: string; base_url: string; pubkey: string; notes?: string }): Peer {
+    const now = Date.now();
+    this.db.prepare(
+      "INSERT INTO peers (name, base_url, pubkey, added_at, last_seen, notes) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run(opts.name, opts.base_url, opts.pubkey, now, null, opts.notes ?? null);
+    return {
+      name: opts.name,
+      base_url: opts.base_url,
+      pubkey: opts.pubkey,
+      added_at: now,
+      last_seen: null,
+      notes: opts.notes ?? null,
+    };
+  }
+
+  getPeer(name: string): Peer | null {
+    return this.db.prepare("SELECT * FROM peers WHERE name = ?").get(name) as Peer | null;
+  }
+
+  getPeerByPubkey(pubkey: string): Peer | null {
+    return this.db.prepare("SELECT * FROM peers WHERE pubkey = ?").get(pubkey) as Peer | null;
+  }
+
+  listPeers(): Peer[] {
+    return this.db.prepare("SELECT * FROM peers ORDER BY name").all() as Peer[];
+  }
+
+  deletePeer(name: string): void {
+    this.db.prepare("DELETE FROM peers WHERE name = ?").run(name);
+  }
+
+  updatePeerUrl(name: string, base_url: string): void {
+    this.db.prepare("UPDATE peers SET base_url = ? WHERE name = ?").run(base_url, name);
+  }
+
+  updatePeerLastSeen(name: string, ts: number): void {
+    this.db.prepare("UPDATE peers SET last_seen = ? WHERE name = ?").run(ts, name);
   }
 
   close(): void {


### PR DESCRIPTION
PR 1 of 3 for wire#9. Scaffolds peers table, Ed25519 server identity, and the wire peer admin CLI. No forwarding yet — PR 2.

Smoke-tested: all 5 peer subcommands round-trip cleanly.