### PR TITLE
feat: federation forwarding (wire#9 PR 2 of 3); v1.1.0-alpha.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "1.1.0-alpha.1",
+  "version": "1.1.0-alpha.2",
   "description": "The Wire — persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {

--- a/src/federation.test.ts
+++ b/src/federation.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { Store } from "./store";
+import { loadOrCreateServerIdentity } from "./identity";
+import { signForwardedEnvelope, verifyForwardedJwt, type ForwardedEnvelope } from "./federation";
+
+let tmpDir: string;
+let dbPath: string;
+let store: Store;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "wire-fed-"));
+  dbPath = join(tmpDir, "wire.db");
+  store = new Store(dbPath);
+});
+
+afterAll(() => {
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+const SAMPLE_ENVELOPE: ForwardedEnvelope = {
+  source: "brioche",
+  dest: "danish",
+  topic: "ipc",
+  payload: JSON.stringify({ from: "brioche", kind: "ack", text: "hi" }),
+};
+
+describe("federation sign + verify", () => {
+  test("sign + verify round-trip succeeds with the correct pubkey", async () => {
+    const identity = await loadOrCreateServerIdentity(join(tmpDir, "server.key"));
+    // The recipient's store has us registered as peer "laptop".
+    store.createPeer({ name: "laptop", base_url: "https://laptop.local", pubkey: identity.pubkeyB64 });
+
+    const { jwt, body } = await signForwardedEnvelope("laptop", identity, SAMPLE_ENVELOPE);
+    const { peer, envelope } = await verifyForwardedJwt(jwt, body, store);
+    expect(peer.name).toBe("laptop");
+    expect(envelope.source).toBe("brioche");
+    expect(envelope.dest).toBe("danish");
+  });
+
+  test("tampered body fails body_hash check", async () => {
+    const identity = await loadOrCreateServerIdentity(join(tmpDir, "server.key"));
+    store.createPeer({ name: "laptop", base_url: "https://laptop.local", pubkey: identity.pubkeyB64 });
+
+    const { jwt } = await signForwardedEnvelope("laptop", identity, SAMPLE_ENVELOPE);
+    const tamperedBody = JSON.stringify({ ...SAMPLE_ENVELOPE, payload: "evil" });
+    await expect(verifyForwardedJwt(jwt, tamperedBody, store)).rejects.toThrow(/body_hash/);
+  });
+
+  test("unknown peer rejected", async () => {
+    const identity = await loadOrCreateServerIdentity(join(tmpDir, "server.key"));
+    // Do NOT register the peer.
+    const { jwt, body } = await signForwardedEnvelope("unregistered", identity, SAMPLE_ENVELOPE);
+    await expect(verifyForwardedJwt(jwt, body, store)).rejects.toThrow(/unknown peer/);
+  });
+
+  test("wrong-pubkey registration rejected", async () => {
+    const identityA = await loadOrCreateServerIdentity(join(tmpDir, "server-a.key"));
+    const identityB = await loadOrCreateServerIdentity(join(tmpDir, "server-b.key"));
+    // Recipient has us as peer=laptop but with B's pubkey; we sign with A.
+    store.createPeer({ name: "laptop", base_url: "https://laptop.local", pubkey: identityB.pubkeyB64 });
+    const { jwt, body } = await signForwardedEnvelope("laptop", identityA, SAMPLE_ENVELOPE);
+    await expect(verifyForwardedJwt(jwt, body, store)).rejects.toThrow(/signature verification failed/);
+  });
+
+  test("malformed JWT rejected", async () => {
+    await expect(verifyForwardedJwt("not.a.jwt.maybe", "{}", store)).rejects.toThrow(/malformed JWT/);
+    await expect(verifyForwardedJwt("only.two", "{}", store)).rejects.toThrow(/malformed JWT/);
+  });
+});

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -1,0 +1,214 @@
+/**
+ * Wire federation — peer-to-peer message forwarding.
+ *
+ * When a unicast message's dest is not a locally-registered agent,
+ * we ask peers whether they host the agent and forward on the first
+ * positive match. The outer envelope is signed by our server
+ * identity (Ed25519); the receiving Wire verifies against the pubkey
+ * stored when the two Wires were paired.
+ *
+ * Trust model:
+ *   - Each Wire's server identity (Ed25519) is generated on first boot
+ *     and persisted at ~/.wire/server.key.
+ *   - Admin pairs two Wires by exchanging pubkeys out-of-band
+ *     (`wire peer pubkey` / `wire peer add`).
+ *   - A peer-forwarded message arrives at /peers/forward wrapped in a
+ *     JWT signed by the source Wire's key. Recipient looks up the
+ *     pubkey by the iss claim (which is the peer's registered name),
+ *     verifies, and — if the inner envelope's body_hash matches —
+ *     passes the envelope into its own router for local delivery.
+ *
+ * The inner envelope's own agent signature is untouched — the
+ * recipient agent verifies that separately (same as local delivery).
+ */
+
+import type { Logger } from "pino";
+import type { Store, Peer } from "./store.js";
+import type { ServerIdentity } from "./identity.js";
+
+/** Result of an attempted peer forward. */
+export type ForwardResult =
+  | { ok: true; peer: string; remoteSeq?: number }
+  | { ok: false; peer: string; error: string }
+  | { ok: false; error: "no_peer_claims_dest" };
+
+/** Shape of the POST /peers/forward body. */
+export type ForwardedEnvelope = {
+  source: string;
+  source_id?: string | null;
+  source_cc_session?: string | null;
+  dest: string;
+  dest_cc_session?: string | null;
+  topic: string;
+  payload: string;
+  raw?: string | null;
+};
+
+// --- Crypto helpers ---
+
+async function sha256Hex(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function b64url(bytes: ArrayBuffer | Uint8Array): string {
+  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  return Buffer.from(u8).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromB64Url(s: string): Uint8Array {
+  const pad = "=".repeat((4 - (s.length % 4)) % 4);
+  return new Uint8Array(Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/") + pad, "base64"));
+}
+
+/** Import a peer's base64 Ed25519 pubkey into a CryptoKey for verify(). */
+async function importPeerPubkey(b64: string): Promise<CryptoKey> {
+  // Try base64 first, fall back to base64url (wire-tools' derivePublicKeyB64
+  // emits base64url without padding).
+  let bytes: Uint8Array;
+  try {
+    bytes = new Uint8Array(Buffer.from(b64, "base64"));
+    if (bytes.length !== 32) throw new Error("length");
+  } catch {
+    bytes = fromB64Url(b64);
+  }
+  return crypto.subtle.importKey("raw", bytes, { name: "Ed25519" }, false, ["verify"]);
+}
+
+/**
+ * Sign a forwarded envelope. Produces an EdDSA JWT whose payload
+ * binds the body hash + our own peer name, so the recipient verifies
+ * that the envelope was sent by us and hasn't been tampered with.
+ */
+export async function signForwardedEnvelope(
+  ourPeerName: string,
+  ourIdentity: ServerIdentity,
+  envelope: ForwardedEnvelope,
+): Promise<{ jwt: string; body: string }> {
+  const body = JSON.stringify(envelope);
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const payload = {
+    iss: `wire:${ourPeerName}`,
+    body_hash: await sha256Hex(body),
+    iat: Math.floor(Date.now() / 1000),
+  };
+  const signingInput = `${b64url(new TextEncoder().encode(JSON.stringify(header)))}.${b64url(new TextEncoder().encode(JSON.stringify(payload)))}`;
+  const sig = await crypto.subtle.sign(
+    "Ed25519",
+    ourIdentity.privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+  return { jwt: `${signingInput}.${b64url(sig)}`, body };
+}
+
+/**
+ * Verify a peer-forwarded envelope. Returns the source peer's name on
+ * success. Throws with a helpful message on any failure — no ambiguity.
+ */
+export async function verifyForwardedJwt(
+  jwt: string,
+  body: string,
+  store: Store,
+): Promise<{ peer: Peer; envelope: ForwardedEnvelope }> {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) throw new Error("malformed JWT");
+  const [h, p, s] = parts;
+  const header = JSON.parse(new TextDecoder().decode(fromB64Url(h!)));
+  if (header.alg !== "EdDSA") throw new Error(`unexpected alg: ${header.alg}`);
+  const payload = JSON.parse(new TextDecoder().decode(fromB64Url(p!)));
+  const iss: string = payload.iss ?? "";
+  if (!iss.startsWith("wire:")) throw new Error(`unexpected iss: ${iss}`);
+  const peerName = iss.slice("wire:".length);
+  const peer = store.getPeer(peerName);
+  if (!peer) throw new Error(`unknown peer: ${peerName}`);
+
+  // Recompute body hash.
+  const expected = await sha256Hex(body);
+  if (payload.body_hash !== expected) throw new Error("body_hash mismatch");
+
+  const pubkey = await importPeerPubkey(peer.pubkey);
+  const signingInput = new TextEncoder().encode(`${h}.${p}`);
+  const ok = await crypto.subtle.verify("Ed25519", pubkey, fromB64Url(s!), signingInput);
+  if (!ok) throw new Error("signature verification failed");
+
+  const envelope = JSON.parse(body) as ForwardedEnvelope;
+  return { peer, envelope };
+}
+
+// --- HTTP helpers ---
+
+/**
+ * Ask a peer whether they host `agentId`. Returns true on 200, false
+ * on 404, throws on anything else (auth / network / unexpected).
+ */
+export async function peerHasAgent(peer: Peer, agentId: string): Promise<boolean> {
+  const res = await fetch(`${peer.base_url}/peers/agents/${encodeURIComponent(agentId)}`, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  if (res.status === 200) return true;
+  if (res.status === 404) return false;
+  throw new Error(`peer probe ${peer.name} returned ${res.status}: ${await res.text().catch(() => "")}`);
+}
+
+/** Forward a signed envelope to a peer Wire. */
+export async function forwardToPeer(
+  peer: Peer,
+  ourPeerName: string,
+  ourIdentity: ServerIdentity,
+  envelope: ForwardedEnvelope,
+  log?: Logger,
+): Promise<ForwardResult> {
+  try {
+    const { jwt, body } = await signForwardedEnvelope(ourPeerName, ourIdentity, envelope);
+    const res = await fetch(`${peer.base_url}/peers/forward`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${jwt}`,
+      },
+      body,
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      log?.warn({ event: "forward_fail", peer: peer.name, status: res.status, body: text }, "peer forward failed");
+      return { ok: false, peer: peer.name, error: `peer responded ${res.status}: ${text.slice(0, 200)}` };
+    }
+    let remoteSeq: number | undefined;
+    try {
+      const json = await res.json();
+      if (typeof (json as { seq?: number }).seq === "number") remoteSeq = (json as { seq: number }).seq;
+    } catch { /* body might not be JSON */ }
+    log?.info({ event: "forward_ok", peer: peer.name, dest: envelope.dest, remoteSeq }, "peer forward ok");
+    return { ok: true, peer: peer.name, remoteSeq };
+  } catch (e) {
+    return { ok: false, peer: peer.name, error: (e as Error).message };
+  }
+}
+
+/**
+ * Find the peer that claims `agentId`. Iterates peers in parallel
+ * and returns the first positive match. Probe failures are treated
+ * as negative (not fatal) so one dead peer doesn't block discovery.
+ */
+export async function findPeerForAgent(
+  store: Store,
+  agentId: string,
+  log?: Logger,
+): Promise<Peer | null> {
+  const peers = store.listPeers();
+  if (peers.length === 0) return null;
+  // Parallel probes. First positive wins.
+  const probes = peers.map(async (p) => {
+    try {
+      const has = await peerHasAgent(p, agentId);
+      return has ? p : null;
+    } catch (e) {
+      log?.debug({ event: "peer_probe_fail", peer: p.name, err: (e as Error).message }, "peer probe failed");
+      return null;
+    }
+  });
+  const results = await Promise.all(probes);
+  return results.find((r) => r !== null) ?? null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,13 +52,19 @@ process.on("uncaughtException", (err) => {
 
 const store = new Store(dbPath);
 const emitter = new MessageEmitter();
-const router = new Router(store, emitter, log);
-const heartbeats = new HeartbeatScheduler(store, router, log);
 
 // Server identity — Ed25519 keypair for peer-to-peer federation (v1.1.0).
 // Generated on first boot; pubkey is what you paste when peering.
 const serverIdentity = await loadOrCreateServerIdentity();
 log.info({ event: "server_identity", pubkey: serverIdentity.pubkeyB64 }, "server identity loaded");
+
+// Our peer name in outgoing JWTs — defaults to hostname but can be
+// overridden via WIRE_PEER_NAME so two Wires on the same hostname
+// can coexist (dev / test / CI).
+const ourPeerName = (process.env.WIRE_PEER_NAME ?? "").trim() || require("os").hostname().toLowerCase();
+
+const router = new Router(store, emitter, log, { ourPeerName, identity: serverIdentity });
+const heartbeats = new HeartbeatScheduler(store, router, log);
 
 const server = createServer({ port, store, router, emitter, log, heartbeats });
 heartbeats.start();

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,10 +9,24 @@
 import type { Logger } from "pino";
 import type { Store, Message } from "./store.js";
 import type { MessageEmitter } from "./emitter.js";
+import type { ServerIdentity } from "./identity.js";
+import { findPeerForAgent, forwardToPeer, type ForwardedEnvelope } from "./federation.js";
+
+/**
+ * Federation hook passed into Router at construction. When present,
+ * the router tries to forward offline-unicast messages via peer Wires
+ * before falling back to 'offline' status.
+ */
+export type RouterFederation = {
+  ourPeerName: string;
+  identity: ServerIdentity;
+};
 
 export type DeliveryResult = {
   agentId: string;
-  status: "delivered" | "offline";
+  status: "delivered" | "offline" | "forwarded" | "forward_failed";
+  peer?: string;
+  error?: string;
 };
 
 export type RouteListener = (msg: Message, deliveries: DeliveryResult[]) => void;
@@ -20,13 +34,21 @@ export type RouteListener = (msg: Message, deliveries: DeliveryResult[]) => void
 export class Router {
   private routeListeners = new Set<RouteListener>();
   private log: Logger;
+  private federation: RouterFederation | undefined;
 
   constructor(
     private store: Store,
     private emitter: MessageEmitter,
     log: Logger,
+    federation?: RouterFederation,
   ) {
     this.log = log.child({ component: "router" });
+    this.federation = federation;
+  }
+
+  /** Wire up federation after construction (lets us defer identity load). */
+  setFederation(federation: RouterFederation): void {
+    this.federation = federation;
   }
 
   onRoute(listener: RouteListener): () => void {
@@ -87,6 +109,19 @@ export class Router {
         delivered = this.emitter.emit(agentId, data, stored.seq);
       }
 
+      // If offline locally AND this is a unicast + federation is on,
+      // try to forward to a peer that claims this agent. The forward is
+      // fire-and-forget — the HTTP caller sees status="forwarding"
+      // immediately; success/failure lands in logs.
+      if (!delivered && msg.dest && this.federation) {
+        this.dispatchFederationForward(stored, agentId, msg).catch((e) => {
+          this.log.error({ event: "federation_dispatch_error", dest: agentId, err: e }, "federation dispatch failed");
+        });
+        this.store.logDelivery(stored.seq, agentId, "forwarding");
+        deliveries.push({ agentId, status: "forwarded" });
+        continue;
+      }
+
       const status = delivered ? "delivered" : "offline";
       this.store.logDelivery(stored.seq, agentId, delivered ? "ok" : "skipped_offline");
       deliveries.push({ agentId, status });
@@ -100,6 +135,41 @@ export class Router {
     }
 
     return { message: stored, deliveries };
+  }
+
+  /**
+   * Find a peer that claims the dest agent and forward the stored envelope.
+   * Runs async so route() stays synchronous; result is logged.
+   */
+  private async dispatchFederationForward(
+    stored: Message,
+    agentId: string,
+    original: { source: string; source_id?: string; source_cc_session?: string; dest?: string; dest_cc_session?: string; topic: string; payload: string; raw?: string },
+  ): Promise<void> {
+    const fed = this.federation!;
+    const peer = await findPeerForAgent(this.store, agentId, this.log);
+    if (!peer) {
+      this.log.info({ event: "federation_no_peer", dest: agentId, seq: stored.seq }, "no peer claims agent");
+      this.store.logDelivery(stored.seq, agentId, "forward_no_peer");
+      return;
+    }
+    const envelope: ForwardedEnvelope = {
+      source: original.source,
+      source_id: original.source_id ?? null,
+      source_cc_session: original.source_cc_session ?? null,
+      dest: agentId,
+      dest_cc_session: original.dest_cc_session ?? null,
+      topic: original.topic,
+      payload: original.payload,
+      raw: original.raw ?? null,
+    };
+    const result = await forwardToPeer(peer, fed.ourPeerName, fed.identity, envelope, this.log);
+    if (result.ok) {
+      this.store.updatePeerLastSeen(peer.name, Date.now());
+      this.store.logDelivery(stored.seq, agentId, `forwarded_to:${peer.name}`);
+    } else {
+      this.store.logDelivery(stored.seq, agentId, `forward_failed:${peer.name}:${"error" in result ? result.error.slice(0, 100) : ""}`);
+    }
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -280,6 +280,48 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
     return c.json({ status: "ok", ts: Date.now() });
   });
 
+  // --- Federation (v1.1.0) ---
+  // GET /peers/agents/:id  — unauthenticated existence probe. Returns
+  //   200 if the agent is locally registered, 404 otherwise. Peers call
+  //   this to decide whether to forward a message to us.
+  app.get("/peers/agents/:id", (c) => {
+    const id = c.req.param("id");
+    const agent = store.getAgent(id);
+    if (agent) return c.json({ ok: true, id });
+    return c.json({ ok: false, id }, 404);
+  });
+
+  // POST /peers/forward  — accept a message forwarded by a peer Wire.
+  //   Authorization: Bearer <outer-JWT> signed by the peer's server
+  //   identity. Body is the original envelope exactly as the peer's
+  //   router stored it. We verify the JWT, then call router.route so
+  //   the message lands in our own store + reaches the local agent.
+  app.post("/peers/forward", async (c) => {
+    const auth = c.req.header("authorization") ?? "";
+    const jwt = auth.replace(/^Bearer /, "");
+    if (!jwt) return c.json({ error: "missing Bearer JWT" }, 401);
+    const body = (c as any).get("rawBody") ?? await c.req.text();
+    try {
+      const { verifyForwardedJwt } = await import("./federation.js");
+      const { peer, envelope } = await verifyForwardedJwt(jwt, body, store);
+      // Route through normal pipeline so local storage + delivery both happen.
+      const { message, deliveries } = router.route({
+        source: envelope.source,
+        source_id: envelope.source_id ?? undefined,
+        source_cc_session: envelope.source_cc_session ?? undefined,
+        dest: envelope.dest,
+        dest_cc_session: envelope.dest_cc_session ?? undefined,
+        topic: envelope.topic,
+        payload: envelope.payload,
+        raw: envelope.raw ?? undefined,
+      });
+      store.updatePeerLastSeen(peer.name, Date.now());
+      return c.json({ seq: message.seq, delivered_to: deliveries, forwarded_by: peer.name });
+    } catch (e) {
+      return c.json({ error: "peer forward rejected", detail: (e as Error).message }, 401);
+    }
+  });
+
   // --- Agent Registry ---
 
   app.get("/agents", (c) => {


### PR DESCRIPTION
PR 2 of 3 for wire#9. Adds peer-to-peer message forwarding with JWT-signed envelopes.

5/5 crypto tests pass; live HTTP test pending a second machine.