### PR TITLE
fix: refresh created_at on agent re-admission; v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The Wire \u2014 persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {

--- a/src/store.ts
+++ b/src/store.ts
@@ -414,6 +414,7 @@ export class Store {
         permanent = CASE WHEN excluded.permanent = 1 THEN 1 ELSE agents.permanent END,
         pronouns = COALESCE(excluded.pronouns, agents.pronouns),
         last_seen_at = excluded.last_seen_at,
+        created_at = excluded.created_at,
         reaped_at = NULL
     `).run(agent.id, agent.display_name, agent.pubkey, agent.permanent ? 1 : 0, agent.pronouns ?? null, now, now);
   }


### PR DESCRIPTION
## Summary

- `upsertAgent` ON CONFLICT was updating `last_seen_at` and `pubkey` but not `created_at`. The reaper's 5-min new-agent grace period (`cleanEphemeralAgents`: `created_at < (now - 5min)`) is keyed on creation timestamp, so re-admitted ephemerals with old `created_at` became reapable on the very next 10-second reconcile tick — even seconds after a successful upsert.
- Observed today (2026-05-04): Beignet's record was un-reaped at 16:39:28, reaped again at 16:39:32 — 4 seconds later — before her CC process even started boot. Orphan-spawn pattern unrecoverable.
- Fix: refresh `created_at` on every upsert. Grace window now applies to re-admissions the same as fresh registrations.

## Test plan

- [ ] Smoke: deploy v1.1.2, observe a sponsor-spawn cycle (`register_agent` → `agent_launch`) for an agent whose record exists from a prior run; agent should connect and remain alive.
- [ ] Verify reap log: `ephemeral_cleanup` should NOT fire within 5 min of a successful re-admission upsert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)