### PR TITLE
fix: reject silent key rotation on /agents/register; v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "The Wire \u2014 persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -361,7 +361,7 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
 
   app.post("/agents/register", async (c) => {
     const body = await c.req.json();
-    const { id, display_name, pubkey, permanent, pronouns } = body;
+    const { id, display_name, pubkey, permanent, pronouns, force_rotate } = body;
 
     if (!id || !display_name || !pubkey) {
       return c.json({ error: "missing required fields: id, display_name, pubkey" }, 400);
@@ -369,6 +369,21 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
 
     const existing = store.getAgent(id);
     const reaped = !existing ? store.getReapedAgent(id) : null;
+
+    // Reject silent key rotation. If a record exists (live or reaped) with a
+    // different pubkey and the caller didn't pass force_rotate=true, fail
+    // loudly so a sponsor doesn't accidentally orphan a still-running process
+    // that holds the previous private key (the Eclair-on-2026-05-01 case).
+    const priorPubkey = existing?.pubkey ?? reaped?.pubkey ?? null;
+    if (priorPubkey && priorPubkey !== pubkey && !force_rotate) {
+      return c.json({
+        error: `agent '${id}' already registered with a different key. Pass force_rotate=true to replace the keypair (this will permanently lock out any process still holding the previous private key).`,
+        code: "agent_exists_pubkey_mismatch",
+        existing: !!existing,
+        reaped: !!reaped,
+      }, 409);
+    }
+
     let authPath: string;
     if (existing && existing.permanent) {
       authPath = "permanent-reregister";


### PR DESCRIPTION
## Summary

- When a sponsor calls `register_agent` for an existing agent id with a different pubkey, the server previously upserted unconditionally — orphaning any process still holding the previous private key. The reaped-readmission self-recovery path then fails (new pubkey in DB vs. old pubkey in memory), zombying the agent with 30s 403-retry loops forever.
- Observed 2026-05-01: Eclair re-registered at 17:16 with `pubkeyMatch:false`, reaped at 17:18, her PID 1150 wire-channel plugin spent 15+ minutes in `register_retry_failed` ("unknown sender: eclair").
- Fix: reject pubkey mismatch on existing/reaped records with 409 + `code: agent_exists_pubkey_mismatch`. Sponsors must pass `force_rotate=true` to opt into key replacement.

## Test plan

- [ ] Existing agent + same pubkey → 201 (existing flows unchanged)
- [ ] Existing agent + different pubkey, no force_rotate → 409
- [ ] Existing agent + different pubkey + force_rotate=true → 201 with new key
- [ ] Reaped agent + same pubkey → 201 (readmission unchanged)
- [ ] Reaped agent + different pubkey, no force_rotate → 409
- [ ] Reaped agent + different pubkey + force_rotate=true → 201

Pairs with wire-ipc-tools follow-up (force_rotate plumbed into `register_agent` MCP tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)