### PR TITLE
fix: longer reap TTL for never-connected ephemerals; v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "The Wire \u2014 persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,8 @@ const dbPath = process.env.WIRE_DB ?? `${process.env.HOME}/.wire/wire.db`;
 const staleMs = parseInt(process.env.STALE_MS ?? "15000", 10);
 const disconnectMs = parseInt(process.env.DISCONNECT_MS ?? "60000", 10);
 const reconcilerIntervalMs = parseInt(process.env.RECONCILER_INTERVAL_MS ?? "10000", 10);
-const ephemeralTtlMs = parseInt(process.env.EPHEMERAL_TTL_MS ?? "300000", 10); // 5 minutes — must exceed agent boot time
+const ephemeralTtlMs = parseInt(process.env.EPHEMERAL_TTL_MS ?? "300000", 10); // 5 minutes — applies to agents that have opened at least one session
+const ephemeralNeverConnectedTtlMs = parseInt(process.env.EPHEMERAL_NEVER_CONNECTED_TTL_MS ?? "1800000", 10); // 30 minutes — applies to agents that have NEVER opened a session (slow plugin bootstrap headroom)
 
 export const log = pino({ name: "wire" });
 
@@ -154,7 +155,7 @@ setInterval(() => {
   } catch {}
 
   // Before reaping ephemeral agents, run client-provided cleanup code for their webhooks
-  const candidates = store.getEphemeralCandidates(ephemeralTtlMs);
+  const candidates = store.getEphemeralCandidates(ephemeralTtlMs, ephemeralNeverConnectedTtlMs);
   for (const agentId of candidates) {
     const webhooks = store.getWebhooksForAgent(agentId);
     for (const wh of webhooks) {
@@ -170,7 +171,7 @@ setInterval(() => {
     }
   }
 
-  const removed = store.cleanEphemeralAgents(ephemeralTtlMs);
+  const removed = store.cleanEphemeralAgents(ephemeralTtlMs, ephemeralNeverConnectedTtlMs);
   if (removed.length > 0) {
     log.info({ event: "ephemeral_cleanup", agents: removed }, `removed ${removed.length} ephemeral agent(s)`);
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -652,8 +652,23 @@ export class Store {
   /**
    * Get ephemeral agent IDs that are candidates for reaping (without deleting).
    */
-  getEphemeralCandidates(ttlMs: number): string[] {
-    const cutoff = Date.now() - ttlMs;
+  /**
+   * Reap-candidate query. Two TTLs:
+   *
+   *   ttlMs              applies to agents that have at least one session row
+   *                      (i.e. their plugin booted, registered a session, then
+   *                      went silent). 5 min is fine — they were healthy.
+   *
+   *   neverConnectedTtlMs applies to agents that have NEVER opened a session.
+   *                      This is the slow-spawn case (Crumpet 2026-05-04: bun
+   *                      install + handshake exceeded 5 min). Reap longer to
+   *                      give plugin bootstrap headroom, but still reap so
+   *                      abandoned registrations don't leak forever.
+   */
+  getEphemeralCandidates(ttlMs: number, neverConnectedTtlMs: number): string[] {
+    const now = Date.now();
+    const sessionCutoff = now - ttlMs;
+    const neverConnectedCutoff = now - neverConnectedTtlMs;
     return (this.db.prepare(`
       SELECT a.id FROM agents a
       WHERE a.permanent = 0
@@ -666,12 +681,16 @@ export class Store {
           SELECT 1 FROM agent_sessions s
           WHERE s.agent_id = a.id AND s.last_heartbeat > ?
         )
-        AND a.created_at < ?
-    `).all(cutoff, cutoff) as { id: string }[]).map((r) => r.id);
+        AND CASE
+          WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id)
+            THEN a.created_at < ?
+          ELSE a.created_at < ?
+        END
+    `).all(sessionCutoff, sessionCutoff, neverConnectedCutoff) as { id: string }[]).map((r) => r.id);
   }
 
-  cleanEphemeralAgents(ttlMs: number): string[] {
-    const candidates = this.getEphemeralCandidates(ttlMs);
+  cleanEphemeralAgents(ttlMs: number, neverConnectedTtlMs: number): string[] {
+    const candidates = this.getEphemeralCandidates(ttlMs, neverConnectedTtlMs);
 
     for (const id of candidates) {
       this.db.prepare("DELETE FROM webhooks WHERE agent_id = ?").run(id);


### PR DESCRIPTION
## Summary

- Third slow-spawn repro this week: Crumpet (2026-05-04 15:04 → reaped 15:09:41) hit the 5-min ephemeral TTL during plugin bootstrap. Fresh registration, no `created_at` staleness, no key-rotation conflict — `bun install` + MCP handshake just took longer than the grace window. v1.1.2 and v1.1.3 don't cover this case because the agent never opens a session.
- Fix: split the ephemeral reap query by whether the agent has ever had a session row. Agents with at least one session keep the existing 5-min TTL (`EPHEMERAL_TTL_MS`). Agents that have NEVER opened a session get a longer grace (default 30 min, env override `EPHEMERAL_NEVER_CONNECTED_TTL_MS`).
- Long enough for slow plugin bootstrap; short enough that abandoned registrations still get reaped.

## Test plan

- [ ] Fresh registration that opens a session within 5 min → no reap (current behavior).
- [ ] Fresh registration that opens a session at t=10 min → still reaped only if it goes silent for 5 min after connecting (still applies the post-connect TTL).
- [ ] Fresh registration that NEVER opens a session, t=10 min → not yet reaped.
- [ ] Fresh registration that NEVER opens a session, t=35 min → reaped.
- [ ] Existing connected-and-silent agent at t=6 min → reaped (unchanged from v1.1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)