### PR TITLE
feat: agent lifecycle state machine — connecting/connected/greyed/deleted; v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agiterra/wire",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "The Wire \u2014 persistent multi-agent message broker, event log, and registry.",
   "type": "module",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,11 +52,17 @@ if (cliResult.exit !== -1) {
 
 const port = parseInt(process.env.WIRE_PORT ?? "9800", 10);
 const dbPath = process.env.WIRE_DB ?? `${process.env.HOME}/.wire/wire.db`;
-// Heartbeat: 10s interval from clients. Stale after 15s, disconnected after 60s.
-const staleMs = parseInt(process.env.STALE_MS ?? "15000", 10);
-const disconnectMs = parseInt(process.env.DISCONNECT_MS ?? "60000", 10);
+// Heartbeat: 10s interval from clients. Stale after 20s, disconnected after 30s.
+const staleMs = parseInt(process.env.STALE_MS ?? "20000", 10);
+const disconnectMs = parseInt(process.env.DISCONNECT_MS ?? "30000", 10);
 const reconcilerIntervalMs = parseInt(process.env.RECONCILER_INTERVAL_MS ?? "10000", 10);
-const ephemeralTtlMs = parseInt(process.env.EPHEMERAL_TTL_MS ?? "300000", 10); // 5 minutes — must exceed agent boot time
+// Lifecycle (v1.2.0): two-phase reap.
+//   reapGraceMs   — agent goes greyed-out after this long with no session heartbeat
+//                   (and at least this long after register, for never-connected agents)
+//   deleteGraceMs — ephemeral agents are hard-deleted this long after going greyed
+//                   (permanent agents stay greyed indefinitely until they re-register)
+const reapGraceMs = parseInt(process.env.REAP_GRACE_MS ?? "20000", 10);
+const deleteGraceMs = parseInt(process.env.DELETE_GRACE_MS ?? "3600000", 10);
 
 export const log = pino({ name: "wire" });
 
@@ -153,9 +159,22 @@ setInterval(() => {
     }
   } catch {}
 
-  // Before reaping ephemeral agents, run client-provided cleanup code for their webhooks
-  const candidates = store.getEphemeralCandidates(ephemeralTtlMs);
-  for (const agentId of candidates) {
+  // --- Pass 1: soft-reap (grey out) inactive agents ---
+  // Agents with no recent heartbeat (and outside the registration grace
+  // window) get reaped_at set. They remain in the registry, in dashboard,
+  // and remain authenticatable — any heartbeat / send / register clears
+  // the greyed state via clearReap().
+  const softReapIds = store.getSoftReapCandidates(reapGraceMs);
+  for (const agentId of softReapIds) {
+    store.softReapAgent(agentId);
+    log.info({ event: "agent_soft_reap", agent: agentId }, `agent ${agentId} → greyed`);
+  }
+
+  // --- Pass 2: hard-delete greyed ephemerals past the delete grace ---
+  // Permanent agents are excluded by the query — they stay greyed forever
+  // until they re-register. Run webhook cleanup before deleting.
+  const hardDeleteIds = store.getHardDeleteCandidates(deleteGraceMs);
+  for (const agentId of hardDeleteIds) {
     const webhooks = store.getWebhooksForAgent(agentId);
     for (const wh of webhooks) {
       if (wh.cleanup) {
@@ -168,11 +187,8 @@ setInterval(() => {
         });
       }
     }
-  }
-
-  const removed = store.cleanEphemeralAgents(ephemeralTtlMs);
-  if (removed.length > 0) {
-    log.info({ event: "ephemeral_cleanup", agents: removed }, `removed ${removed.length} ephemeral agent(s)`);
+    store.hardDeleteAgent(agentId);
+    log.info({ event: "agent_hard_delete", agent: agentId }, `agent ${agentId} → deleted`);
   }
 }, reconcilerIntervalMs);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -351,11 +351,27 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
 
   app.get("/agents", (c) => {
     const agents = store.getAllAgents();
-    const result = agents.map((a) => ({
-      ...a,
-      online: emitter.isConnected(a.id) || store.hasConnectedSession(a.id),
-      sessions: store.getActiveSessions(a.id).length,
-    }));
+    const result = agents.map((a) => {
+      const online = emitter.isConnected(a.id) || store.hasConnectedSession(a.id);
+      // connection_status drives dashboard rendering:
+      //   connected     — active SSE session, recent heartbeat
+      //   connecting    — registered, no session yet, within reap grace
+      //   disconnected  — soft-reaped (greyed); recoverable on next register/heartbeat
+      let connection_status: "connected" | "connecting" | "disconnected";
+      if (a.reaped_at != null) {
+        connection_status = "disconnected";
+      } else if (online) {
+        connection_status = "connected";
+      } else {
+        connection_status = "connecting";
+      }
+      return {
+        ...a,
+        online,
+        connection_status,
+        sessions: store.getActiveSessions(a.id).length,
+      };
+    });
     return c.json(result);
   });
 
@@ -367,32 +383,32 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
       return c.json({ error: "missing required fields: id, display_name, pubkey" }, 400);
     }
 
+    // getAgent now returns greyed agents too. Distinguish by reaped_at.
     const existing = store.getAgent(id);
-    const reaped = !existing ? store.getReapedAgent(id) : null;
+    const isGreyed = existing != null && existing.reaped_at != null;
 
-    // Reject silent key rotation. If a record exists (live or reaped) with a
-    // different pubkey and the caller didn't pass force_rotate=true, fail
-    // loudly so a sponsor doesn't accidentally orphan a still-running process
-    // that holds the previous private key (the Eclair-on-2026-05-01 case).
-    const priorPubkey = existing?.pubkey ?? reaped?.pubkey ?? null;
-    if (priorPubkey && priorPubkey !== pubkey && !force_rotate) {
+    // Reject silent key rotation. If any record exists with a different pubkey
+    // and the caller didn't pass force_rotate=true, fail loudly so a sponsor
+    // doesn't accidentally orphan a still-running process that holds the
+    // previous private key (the Eclair-on-2026-05-01 case).
+    if (existing && existing.pubkey !== pubkey && !force_rotate) {
       return c.json({
         error: `agent '${id}' already registered with a different key. Pass force_rotate=true to replace the keypair (this will permanently lock out any process still holding the previous private key).`,
         code: "agent_exists_pubkey_mismatch",
-        existing: !!existing,
-        reaped: !!reaped,
+        existing: !isGreyed,
+        reaped: isGreyed,
       }, 409);
     }
 
     let authPath: string;
     if (existing && existing.permanent) {
-      authPath = "permanent-reregister";
-      // Permanent agent re-registering — must prove identity
+      authPath = isGreyed ? "permanent-readmission" : "permanent-reregister";
+      // Permanent agent (alive or greyed) — must prove identity with own key
       const err = await requireAgent(c, id);
       if (err) return err;
-    } else if (existing && !existing.permanent) {
+    } else if (existing && !existing.permanent && !isGreyed) {
       authPath = "ephemeral-reregister";
-      // Ephemeral agent re-registering — allow the agent itself or any sponsoring agent
+      // Ephemeral agent re-registering while still alive — allow the agent itself or any sponsoring agent
       const selfErr = await requireAgent(c, id);
       if (selfErr) {
         const sponsorErr = await requireAgentOrOperator(c);
@@ -404,12 +420,12 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
       const err = requireOperator(c);
       if (err) return err;
     } else {
-      authPath = reaped ? "reaped-readmission" : "new-ephemeral";
-      // New ephemeral agent — check for a reaped agent with matching pubkey (re-admission)
-      if (reaped && reaped.pubkey === pubkey) {
-        // Same agent, same key — let them back in
+      authPath = isGreyed ? "reaped-readmission" : "new-ephemeral";
+      // Greyed ephemeral with matching pubkey: same agent waking up; let them back in.
+      // Truly new ephemeral: requires sponsor or operator auth.
+      if (isGreyed && existing!.pubkey === pubkey) {
+        // pubkey already matches (we'd have rejected mismatch above without force_rotate)
       } else {
-        // Truly new — must be registered by an authenticated agent or operator
         const err = await requireAgentOrOperator(c);
         if (err) return err;
       }
@@ -421,7 +437,7 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
       authPath,
       bodyPermanent: permanent,
       existingPermanent: existing?.permanent ?? null,
-      reaped: !!reaped,
+      greyed: isGreyed,
       pubkeyMatch: existing ? existing.pubkey === pubkey : null,
     }, `REGISTER ${id} via ${authPath}`);
 
@@ -449,6 +465,10 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
     }
 
     store.touchAgent(agentId);
+    // Successful new session = liveness signal. Clear any greyed state.
+    if (store.clearReap(agentId)) {
+      log.info({ event: "agent_un_greyed", agent: agentId, via: "connect" }, `agent ${agentId} → connected (un-greyed)`);
+    }
     // cc_session_id identifies the Claude Code session (survives SSE reconnects)
     const session = store.createSession(agentId, "claude-code", body.cc_session_id);
     notifyDashboard();
@@ -478,6 +498,16 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
 
     store.disconnectSession(session_id);
     emitter.closeAndUnregister(agentId, session_id);
+
+    // Clean shutdown: if this was the agent's last live session, immediately
+    // soft-reap (grey) so the dashboard reflects state without waiting for the
+    // reconciler. Permanent agents stay greyed indefinitely; ephemerals get
+    // hard-deleted after the delete grace.
+    const reapGraceMs = parseInt(process.env.REAP_GRACE_MS ?? "20000", 10);
+    if (!store.agentHasLiveSession(agentId, reapGraceMs)) {
+      store.softReapAgent(agentId);
+      log.info({ event: "agent_soft_reap", agent: agentId, via: "clean_disconnect" }, `agent ${agentId} → greyed (clean shutdown)`);
+    }
     notifyDashboard();
     return c.json({ disconnected: true });
   });
@@ -595,6 +625,10 @@ export function createServer({ port, store, router, emitter, log, heartbeats }: 
     if (err) return err;
 
     store.heartbeatSession(sessionId);
+    // Heartbeat = liveness signal. Clear greyed state if applicable.
+    if (store.clearReap(agentId)) {
+      log.info({ event: "agent_un_greyed", agent: agentId, via: "heartbeat" }, `agent ${agentId} → connected (un-greyed)`);
+    }
     return c.json({ ok: true });
   });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -176,6 +176,8 @@ export type Agent = {
   last_seen_at: number | null;
   plan: string | null;
   pronouns: string | null;
+  /** Timestamp of soft-reap (greyed-out). NULL when agent is active. */
+  reaped_at: number | null;
 };
 
 export type SessionStatus = "connected" | "stale" | "disconnected";
@@ -395,12 +397,32 @@ export class Store {
 
   // --- Agents ---
 
+  /**
+   * Return an agent record. Includes soft-reaped (greyed) agents — being
+   * greyed in the dashboard does not invalidate the agent's identity. JWT
+   * verification still passes against a greyed agent's pubkey, and any
+   * authenticated activity (heartbeat, register, send) clears the greyed
+   * state via clearReap().
+   */
   getAgent(id: string): Agent | null {
-    return (this.db.prepare("SELECT * FROM agents WHERE id = ? AND reaped_at IS NULL").get(id) as Agent) ?? null;
+    return (this.db.prepare("SELECT * FROM agents WHERE id = ?").get(id) as Agent) ?? null;
   }
 
+  /** Return all agents including soft-reaped (greyed) ones. */
   getAllAgents(): Agent[] {
-    return this.db.prepare("SELECT * FROM agents WHERE reaped_at IS NULL").all() as Agent[];
+    return this.db.prepare("SELECT * FROM agents").all() as Agent[];
+  }
+
+  /**
+   * Clear an agent's greyed state. Called whenever an agent demonstrates
+   * liveness — heartbeat success, new session connect, or register upsert.
+   * No-op if reaped_at is already NULL.
+   */
+  clearReap(id: string): boolean {
+    const res = this.db.prepare(
+      "UPDATE agents SET reaped_at = NULL, last_seen_at = ? WHERE id = ? AND reaped_at IS NOT NULL",
+    ).run(Date.now(), id);
+    return res.changes > 0;
   }
 
   upsertAgent(agent: { id: string; display_name: string; pubkey: string; permanent?: boolean; pronouns?: string }): void {
@@ -643,25 +665,27 @@ export class Store {
     ).run(messageSeq, agentId, Date.now(), result, error ?? null);
   }
 
-  // --- Ephemeral agent cleanup ---
+  // --- Agent lifecycle: soft-reap (grey) and hard-delete ---
 
   /**
-   * Clean up ephemeral agents: not permanent, no active sessions,
-   * and not seen within the TTL window.
+   * Soft-reap candidates: agents that should be greyed-out in the dashboard.
+   *
+   * An agent is a candidate when it has demonstrated no liveness within
+   * `reapGraceMs` (default ~20s = 2 heartbeats):
+   *   - no session has heartbeated within the grace window
+   *   - the agent itself was registered before the cutoff (gives never-
+   *     connected agents a brief window to open their first session before
+   *     greying)
+   *
+   * Soft-reap does not delete anything. The agent record stays, sessions stay
+   * (their own status is managed by the session reconciler). Only `reaped_at`
+   * is set, marking the agent as greyed.
    */
-  /**
-   * Get ephemeral agent IDs that are candidates for reaping (without deleting).
-   */
-  getEphemeralCandidates(ttlMs: number): string[] {
-    const cutoff = Date.now() - ttlMs;
+  getSoftReapCandidates(reapGraceMs: number): string[] {
+    const cutoff = Date.now() - reapGraceMs;
     return (this.db.prepare(`
       SELECT a.id FROM agents a
-      WHERE a.permanent = 0
-        AND a.reaped_at IS NULL
-        AND NOT EXISTS (
-          SELECT 1 FROM agent_sessions s
-          WHERE s.agent_id = a.id AND s.status IN ('connected', 'stale')
-        )
+      WHERE a.reaped_at IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM agent_sessions s
           WHERE s.agent_id = a.id AND s.last_heartbeat > ?
@@ -670,21 +694,50 @@ export class Store {
     `).all(cutoff, cutoff) as { id: string }[]).map((r) => r.id);
   }
 
-  cleanEphemeralAgents(ttlMs: number): string[] {
-    const candidates = this.getEphemeralCandidates(ttlMs);
-
-    for (const id of candidates) {
-      this.db.prepare("DELETE FROM webhooks WHERE agent_id = ?").run(id);
-      this.db.prepare("DELETE FROM agent_sessions WHERE agent_id = ?").run(id);
-      this.db.prepare("UPDATE agents SET reaped_at = ? WHERE id = ?").run(Date.now(), id);
-    }
-    return candidates;
+  /** Mark an agent as greyed-out. Idempotent. */
+  softReapAgent(id: string): void {
+    this.db.prepare(
+      "UPDATE agents SET reaped_at = ? WHERE id = ? AND reaped_at IS NULL",
+    ).run(Date.now(), id);
   }
 
-  getReapedAgent(id: string): { id: string; pubkey: string } | null {
-    return (this.db.prepare(
-      "SELECT id, pubkey FROM agents WHERE id = ? AND reaped_at IS NOT NULL"
-    ).get(id) as { id: string; pubkey: string }) ?? null;
+  /**
+   * Hard-delete candidates: ephemeral agents that have been greyed-out for
+   * longer than `deleteGraceMs` (default 1h). Permanent agents are never
+   * hard-deleted — they stay greyed indefinitely until they re-register.
+   */
+  getHardDeleteCandidates(deleteGraceMs: number): string[] {
+    const cutoff = Date.now() - deleteGraceMs;
+    return (this.db.prepare(`
+      SELECT id FROM agents
+      WHERE permanent = 0
+        AND reaped_at IS NOT NULL
+        AND reaped_at < ?
+    `).all(cutoff) as { id: string }[]).map((r) => r.id);
+  }
+
+  /** Hard-delete an agent and its dependent rows. */
+  hardDeleteAgent(id: string): void {
+    this.db.prepare("DELETE FROM webhooks WHERE agent_id = ?").run(id);
+    this.db.prepare("DELETE FROM agent_sessions WHERE agent_id = ?").run(id);
+    this.db.prepare("DELETE FROM agents WHERE id = ?").run(id);
+  }
+
+  /**
+   * Returns true if the agent has any session that is currently connected,
+   * stale, or recently heartbeated within `reapGraceMs`. Used by the
+   * disconnect path to decide whether last-session-gone should trigger an
+   * immediate grey-out (clean shutdown semantics).
+   */
+  agentHasLiveSession(agentId: string, reapGraceMs: number): boolean {
+    const cutoff = Date.now() - reapGraceMs;
+    const row = this.db.prepare(`
+      SELECT 1 FROM agent_sessions
+      WHERE agent_id = ?
+        AND (status IN ('connected', 'stale') OR last_heartbeat > ?)
+      LIMIT 1
+    `).get(agentId, cutoff);
+    return !!row;
   }
 
   // --- Operators ---


### PR DESCRIPTION
## Summary

Replaces the single-phase 5-min ephemeral reap with an explicit lifecycle state machine. Operator spec:

> When Brioche launches an ephemeral agent, they should pretty much immediately appear in the Wire dashboard. When they cannot connect, they should quickly appear as disconnected. If they're shut down cleanly, they should disappear, but if they disconnect without a clean shutdown they should appear greyed out for an hour or so.

## Lifecycle states (visible to dashboard via new `connection_status` field)

| State | Meaning | Transition out |
|---|---|---|
| `connecting` | registered, no session yet | active session → `connected`; `REAP_GRACE_MS` elapses → `disconnected` |
| `connected` | active SSE session + recent heartbeat | no heartbeat for `REAP_GRACE_MS` → `disconnected`; clean disconnect → immediately `disconnected` |
| `disconnected` (greyed) | soft-reaped; `reaped_at IS NOT NULL` | heartbeat / register / connect → un-grey to `connected`; greyed > `DELETE_GRACE_MS` && ephemeral → deleted; permanent → stays greyed indefinitely |

## Why this fixes the Crumpet class

Crumpet (2026-05-04 14:04 register → 14:09 reap, never connected) under the new system:
- 14:04 — appears in dashboard as `connecting` immediately
- 14:04:20 — soft-reaped → dashboard shows `disconnected` (greyed)
- 14:04:20 → 15:04:20 — stays visible in dashboard (operator can debug)
- 15:04:20 — hard-deleted (ephemeral past `DELETE_GRACE_MS`)

If her plugin ever boots within that hour, her register call hits `reaped-readmission` (unchanged behavior), `clearReap` un-greys her, dashboard goes green. No special-cased "never-connected" pathway needed.

## Default values (right-sized to heartbeat cadence)

| Env | Old | New | Rationale |
|---|---|---|---|
| `STALE_MS` | 15000 | 20000 | ~2 heartbeats |
| `DISCONNECT_MS` | 60000 | 30000 | ~3 heartbeats — dashboard shows truth in 30s |
| `REAP_GRACE_MS` | n/a | 20000 | new — soft-reap threshold |
| `DELETE_GRACE_MS` | n/a | 3600000 | new — 1h greyed grace |
| `EPHEMERAL_TTL_MS` | 300000 | **removed** | subsumed by REAP+DELETE |

## Auth model change (load-bearing)

`getAgent` now returns soft-reaped agents (previously filtered them out). JWT auth therefore succeeds for greyed agents — which is what enables `clearReap` on heartbeat. Without this, a greyed agent could not recover via heartbeat alone, only via re-registration.

This subsumes the old `getReapedAgent`, which is removed.

## Test plan

- [x] Soft-reap fires for both ephemeral and permanent after `REAP_GRACE_MS` elapses with no heartbeat (verified via in-process Store fixture)
- [x] Permanent agents never appear in `getHardDeleteCandidates` — they stay greyed indefinitely
- [x] `clearReap` un-greys an agent and refreshes `last_seen_at`
- [x] Ephemeral hard-delete removes row + sessions + webhooks after `DELETE_GRACE_MS`
- [ ] Smoke: deploy v1.2.0, observe a real spawn cycle. Crumpet-equivalent should appear immediately, grey at 20s, recover if plugin boots, disappear after 1h.
- [ ] Smoke: existing connected agent disconnects cleanly → grey instant, then disappears in 1h (ephemeral) or stays greyed (permanent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)