### PR TITLE
Add opt-in early-ACK webhook flag (fixes Slack duplicate-event flood)

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -31,6 +31,18 @@ export type DeliveryResult = {
 
 export type RouteListener = (msg: Message, deliveries: DeliveryResult[]) => void;
 
+/** Input envelope for route()/routeAsync(). */
+export type RouteInput = {
+  source: string;
+  source_id?: string;
+  source_cc_session?: string;
+  dest?: string;
+  dest_cc_session?: string;
+  topic: string;
+  payload: string;
+  raw?: string;
+};
+
 export class Router {
   private routeListeners = new Set<RouteListener>();
   private log: Logger;
@@ -73,27 +85,47 @@ export class Router {
    * dest_cc_session targets a specific Claude Code session (conversation context).
    * Without it, all connected sessions for the agent receive the message.
    */
-  route(msg: {
-    source: string;
-    source_id?: string;
-    source_cc_session?: string;
-    dest?: string;
-    dest_cc_session?: string;
-    topic: string;
-    payload: string;
-    raw?: string;
-  }): { message: Message; deliveries: DeliveryResult[] } {
-    // 1. Write-through: store first, get seq
+  route(msg: RouteInput): { message: Message; deliveries: DeliveryResult[] } {
+    // Write-through: store first (assigns seq), then fan out synchronously.
     const stored = this.store.writeMessage(msg);
+    const deliveries = this.deliver(stored, msg);
+    return { message: stored, deliveries };
+  }
 
-    // 2. Determine recipients. Broadcasts go to every identity — agents AND
-    //    integrations — since integrations subscribe to topics just like
-    //    agents do (e.g. wallet-vault subscribes to wallet.sign.response).
+  /**
+   * Persist synchronously, then fan out asynchronously. For webhook-ingress
+   * paths (ack_early) that must ACK an external sender immediately so its
+   * retry clock (e.g. Slack's ~3s http_timeout) isn't coupled to fan-out
+   * latency. The store write (seq + source_id) completes BEFORE this returns,
+   * so source_id-based dedup is race-safe against a retry that lands while the
+   * fan-out is still pending. Delivery errors are logged, never surfaced to
+   * the already-ACKed caller.
+   */
+  routeAsync(msg: RouteInput): { message: Message } {
+    const stored = this.store.writeMessage(msg);
+    queueMicrotask(() => {
+      try {
+        this.deliver(stored, msg);
+      } catch (e) {
+        this.log.error({ event: "async_deliver_error", seq: stored.seq, err: e }, "deferred webhook delivery failed");
+      }
+    });
+    return { message: stored };
+  }
+
+  /**
+   * Fan a stored message out to its recipients (unicast dest or broadcast)
+   * and notify route listeners. Shared by route() (sync) and routeAsync().
+   */
+  private deliver(stored: Message, msg: RouteInput): DeliveryResult[] {
+    // Determine recipients. Broadcasts go to every identity — agents AND
+    // integrations — since integrations subscribe to topics just like
+    // agents do (e.g. wallet-vault subscribes to wallet.sign.response).
     const recipients = msg.dest
       ? [msg.dest]
       : this.store.getAllAgents("all").map((a) => a.id);
 
-    // 3. Attempt delivery to each recipient
+    // Attempt delivery to each recipient
     const deliveries: DeliveryResult[] = [];
     for (const agentId of recipients) {
       const data = JSON.stringify({
@@ -145,7 +177,7 @@ export class Router {
       }
     }
 
-    return { message: stored, deliveries };
+    return deliveries;
   }
 
   /**
@@ -155,7 +187,7 @@ export class Router {
   private async dispatchFederationForward(
     stored: Message,
     agentId: string,
-    original: { source: string; source_id?: string; source_cc_session?: string; dest?: string; dest_cc_session?: string; topic: string; payload: string; raw?: string },
+    original: RouteInput,
   ): Promise<void> {
     const fed = this.federation!;
     const peer = await findPeerForAgent(this.store, agentId, this.log, this.discoveryCache);

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -151,3 +151,61 @@ describe("POST /agents/:id/webhooks — idempotent registration", () => {
     expect(store.getWebhooksForAgent("fondant", "slack").length).toBe(2);
   });
 });
+
+describe("inbound webhook — ack_early (immediate-ACK + race-safe dedup)", () => {
+  // A trivial always-pass validator returning {source, topic} exercises the
+  // post-validator flow (responder → filter → dedup → route) without forging
+  // Slack's HMAC or a JWT. Mirrors how slack-tools registers (validator +
+  // dedup="payload.event_id" + ack_early), minus the real signature check.
+  const passValidator = `return { source: "testws", topic: "webhook.slack" };`;
+
+  function postEvent(name: string, eventId: string) {
+    return fetch(`${baseUrl}/webhooks/fondant/slack/${name}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ event_id: eventId, type: "event_callback", event: { type: "message" } }),
+    });
+  }
+
+  test("ACKs 200 {queued} and persists the message synchronously BEFORE the ACK", async () => {
+    await register({ plugin: "slack", name: "early", validator: passValidator, dedup: "payload.event_id", ack_early: true });
+
+    const res = await postEvent("early", "EV1");
+    expect(res.status).toBe(200);
+    const json = await res.json() as { seq: number; queued?: boolean; delivered_to?: unknown };
+    expect(json.queued).toBe(true);
+    expect(typeof json.seq).toBe("number");
+    expect(json.delivered_to).toBeUndefined();
+
+    // Race-safety: the row (with source_id) is committed before the ACK
+    // returns, so a retry landing mid-fan-out is still caught by dedup.
+    expect(store.getMessageBySourceId("EV1")).not.toBeNull();
+  });
+
+  test("a retry of the same event_id is dropped at the broker (duplicate), never re-fanned", async () => {
+    await register({ plugin: "slack", name: "early", validator: passValidator, dedup: "payload.event_id", ack_early: true });
+
+    const first = await postEvent("early", "EV2");
+    expect((await first.json() as { queued?: boolean }).queued).toBe(true);
+
+    const retry = await postEvent("early", "EV2");
+    expect(retry.status).toBe(200);
+    const json = await retry.json() as { duplicate?: boolean; delivered?: boolean };
+    expect(json.duplicate).toBe(true);
+    expect(json.delivered).toBe(false);
+
+    // Exactly one row was ever stored for this event_id.
+    const rows = store.getMessages(0, 1000).filter((m) => m.source_id === "EV2");
+    expect(rows.length).toBe(1);
+  });
+
+  test("without ack_early, delivery stays synchronous (caller still gets delivered_to)", async () => {
+    await register({ plugin: "slack", name: "sync", validator: passValidator, dedup: "payload.event_id" });
+
+    const res = await postEvent("sync", "EV3");
+    expect(res.status).toBe(200);
+    const json = await res.json() as { seq: number; queued?: boolean; delivered_to?: unknown[] };
+    expect(json.queued).toBeUndefined();
+    expect(Array.isArray(json.delivered_to)).toBe(true);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -828,7 +828,7 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
     if (err) return err;
 
     const body = await c.req.json();
-    const { plugin, name, validator, webhook_secret, filter: filterExpr, meta, cleanup, dedup, session_id, responder } = body;
+    const { plugin, name, validator, webhook_secret, filter: filterExpr, meta, cleanup, dedup, session_id, responder, ack_early } = body;
 
     if (!plugin) {
       return c.json({ error: "missing plugin" }, 400);
@@ -874,6 +874,7 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
       dedup: dedup ?? undefined,
       sessionId: typeof session_id === "string" && session_id.length > 0 ? session_id : undefined,
       responder: typeof responder === "string" && responder.length > 0 ? responder : undefined,
+      ackEarly: ack_early === true || ack_early === 1,
     });
 
     return c.json({
@@ -1021,15 +1022,30 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
     };
 
     const dedupKey = (c as any).get("dedupKey") as string | undefined;
-    const { message, deliveries } = router.route({
+    const routeInput = {
       source,
       source_id: dedupKey,
       dest: agentId,
       topic,
       payload: JSON.stringify(envelope),
       raw: rawBody,
-    });
+    };
 
+    // ack_early: ACK the sender the instant the message is persisted
+    // (writeMessage commits seq + source_id synchronously inside routeAsync,
+    // so a retry that lands mid-fan-out is still caught by the dedup check
+    // above), then fan out to subscribers asynchronously. Severs an external
+    // sender's retry clock (e.g. Slack's ~3s http_timeout, which otherwise
+    // re-delivers up to 3× under transient fan-out latency and floods
+    // subscribers with duplicates) from downstream delivery cost. Opt-in per
+    // webhook; without it, delivery stays synchronous and the caller receives
+    // the per-recipient delivery result.
+    if (webhook?.ack_early) {
+      const { message } = router.routeAsync(routeInput);
+      return c.json({ seq: message.seq, queued: true });
+    }
+
+    const { message, deliveries } = router.route(routeInput);
     return c.json({
       seq: message.seq,
       delivered_to: deliveries,

--- a/src/store.ts
+++ b/src/store.ts
@@ -247,6 +247,7 @@ export type Webhook = {
   emit: string | null;
   session_id: string | null;
   responder: string | null;
+  ack_early: number;
   created_at: number;
 };
 
@@ -438,6 +439,22 @@ export class Store {
     const whCols5 = this.db.prepare("PRAGMA table_info(webhooks)").all() as { name: string }[];
     if (!whCols5.some((c) => c.name === "responder")) {
       this.db.exec("ALTER TABLE webhooks ADD COLUMN responder TEXT");
+    }
+
+    // ack_early: when 1, wire ACKs the inbound webhook with 200 immediately
+    // after auth + responder + filter + dedup-check, then fans out to
+    // subscribers asynchronously. Decouples an external sender's retry clock
+    // (e.g. Slack's ~3s http_timeout → up to 3 retries) from synchronous
+    // route() fan-out latency, which under intermittent load (WAL checkpoint /
+    // event-loop contention) can cross the sender's timeout and trigger a
+    // self-reinforcing retry storm. The message row is still persisted
+    // synchronously BEFORE the ACK (routeAsync), so source_id dedup stays
+    // race-safe against a retry that arrives mid-fan-out. 0 = legacy
+    // synchronous behavior (caller gets {seq, delivered_to}). See
+    // agiterra/wire#26.
+    const whCols6 = this.db.prepare("PRAGMA table_info(webhooks)").all() as { name: string }[];
+    if (!whCols6.some((c) => c.name === "ack_early")) {
+      this.db.exec("ALTER TABLE webhooks ADD COLUMN ack_early INTEGER NOT NULL DEFAULT 0");
     }
   }
 
@@ -837,16 +854,17 @@ export class Store {
     emit?: string;
     sessionId?: string;
     responder?: string;
+    ackEarly?: boolean;
   }): number {
     const now = Date.now();
     const result = this.db.prepare(`
-      INSERT INTO webhooks (agent_id, plugin, name, validator, secrets_map, filter, meta, cleanup, dedup, emit, session_id, responder, created_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO webhooks (agent_id, plugin, name, validator, secrets_map, filter, meta, cleanup, dedup, emit, session_id, responder, ack_early, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       opts.agentId, opts.plugin, opts.name,
       opts.validator ?? null, opts.secretsMap ?? null,
       opts.filter ?? null, opts.meta ?? null, opts.cleanup ?? null, opts.dedup ?? null, opts.emit ?? null,
-      opts.sessionId ?? null, opts.responder ?? null, now,
+      opts.sessionId ?? null, opts.responder ?? null, opts.ackEarly ? 1 : 0, now,
     );
     return Number(result.lastInsertRowid);
   }


### PR DESCRIPTION
## Bug
Tim flagged (via Brioche, 2026-06-05): the Slack webhook ingress at `the-wire.ngrok.io` intermittently exceeds Slack's ~3s timeout, so Slack re-delivers events up to 3× (`X-Slack-Retry-Reason: http_timeout`, `X-Slack-Retry-Num` 1→3). Every subscriber sees each affected event 3–4×.

## Diagnosis (hard data, last 24h before fix)
- 762 `webhook.slack` rows / **663 distinct `event_id`s → 99 pure duplicates**, each duplicated event at **exactly 4 copies** (original + 3 retries).
- Not constant slowness — a **tail**: most events ACK fine; a subset hit a >3s window and get retried 4×.
- Ruled out as the cause: validator/responder (fast in-memory HMAC + challenge echo), DB size (22k msgs, `freelist=0`, WAL `synchronous=NORMAL` — writes/indexed lookups sub-ms), fan-out (3 subscriptions).
- Root cause is **structural**: `handleWebhook` runs the full synchronous `route()` (recipient resolution, per-recipient SSE emit + `delivery_log` writes, federation dispatch, dashboard route-listener) **before** ACKing Slack. That couples Slack's retry clock to downstream delivery latency; any transient hiccup (WAL checkpoint on a 615 MB store, event-loop contention) → timeout → retry → 3–4× load → more hiccups.

## Fix (generic, opt-in — no per-source special-casing)
- **store**: new `ack_early` webhook column (migration + `Webhook` type + `createWebhook`). Default `0` = unchanged behavior.
- **router**: `route()` split into synchronous persist (`writeMessage` — commits seq + `source_id`) + `deliver()` fan-out. New **`routeAsync()`** persists synchronously, then schedules `deliver()` on a microtask. Persisting *before* returning keeps `source_id` dedup **race-safe** against a retry that lands mid-fan-out.
- **server**: registration parses `ack_early`; when set, `handleWebhook` ACKs `200 {queued}` immediately after auth + responder + filter + dedup-check, then fans out async.

## Tests
3 new cases (33/33 pass): early-ACK returns `{queued}` and persists before the ACK; a same-`event_id` retry is dropped at the broker (`{duplicate}`); the non-`ack_early` path still returns `delivered_to`.

## Rollout / deploy notes
- **Activation needs a gateway restart** (`launchctl kickstart -k gui/$(id -u)/com.wire.gateway`) so the `ack_early` migration runs. Deploy is the operator's call.
- Graceful degradation: an old gateway ignores the `ack_early` body field; a new gateway with a pre-upgrade webhook row treats `ack_early` as `0` until set.
- **Immediate mitigation already live (no deploy):** set `dedup='payload.event_id'` on the two live Slack webhook rows (herald, brioche). Verified — 15/15 distinct event_ids since, 0 duplicates stored. This PR makes that durable + adds the early-ACK that stops the timeouts at the source.
- Pairs with slack-tools `feat/webhook-dedup-early-ack` (sets `ack_early` + `dedup` on registration).

## Follow-up (separate, flagged to Tim)
`wire.db` is ~615 MB of real message payloads (22k rows, not tombstone bloat) — worth a retention policy. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)