### PR TITLE
SSE keepalive: unregister dead writer on enqueue failure

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -672,8 +672,14 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
               keepaliveCount++;
               log.debug({ event: "sse_keepalive", agentId, sessionId, count: keepaliveCount }, "SSE keepalive sent");
             } catch (e) {
+              // Controller already closed (client gone before the abort
+              // handler fired). Stop the timer AND drop the dead writer from
+              // the emitter — matching write()'s cleanup — so live emits stop
+              // hitting it. Leaving it registered wastes an enqueue-throw per
+              // message during reconnect storms. Never rethrows.
               log.warn({ event: "sse_keepalive_fail", agentId, sessionId, err: String(e) }, "SSE keepalive failed");
               clearInterval(keepalive);
+              emitter.unregister(agentId, sessionId!);
             }
           }, 30_000);
 


### PR DESCRIPTION
Symptom-hardening for the 2026-06-05 gateway hang (Tim approved fix+deploy).

When a client vanishes before the abort handler fires, the 30s keepalive enqueues into an already-closed controller → `ERR_INVALID_STATE: Controller is already closed`. The catch cleared the interval but left the writer **registered** in the emitter, so every later live emit kept hitting the dead writer (a thrown enqueue per message) until another path cleaned it up. During reconnect storms that compounds load.

Now the catch also `emitter.unregister()`s — matching `write()`'s existing cleanup — and never rethrows.

**Scope:** this is the *symptom*. The flap's root cause (reconnect/replay storms starving the single-thread event loop) is addressed by:
- widened reap hysteresis (`STALE_MS` 20s→45s, `DISCONNECT_MS` 30s→75s, `REAP_GRACE_MS` 20s→45s in `~/.wire/.env`) — client heartbeats every 10s, old defaults tolerated only ~1 miss — deployed alongside this.
- a planned **replay-throttle** (separate, careful PR): replay can't be naively chunked because `ackSession` uses `MAX(last_ack_seq)` + the client acks per-event, so a live message interleaving a chunked replay would advance the cursor past undelivered backlog and lose it on a mid-replay disconnect. Needs buffer-during-replay. See wire open-thread #3.

Tests: 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)