### PR TITLE
Chunk SSE backlog replay with buffer-during-replay (flap root fix)

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from "bun:test";
+import { MessageEmitter } from "./emitter";
+
+function mockWriter() {
+  const frames: string[] = [];
+  return {
+    frames,
+    writer: { write: (d: string) => { frames.push(d); }, close: () => {} },
+    /** seqs of `id:`-tagged frames, in delivery order */
+    seqs: () =>
+      frames
+        .map((f) => { const m = f.match(/^id: (\d+)/); return m ? Number(m[1]) : null; })
+        .filter((s): s is number => s != null),
+  };
+}
+
+describe("MessageEmitter — basic delivery", () => {
+  test("emit delivers to a registered session", () => {
+    const em = new MessageEmitter();
+    const w = mockWriter();
+    em.register("a", "s1", w.writer);
+    expect(em.emit("a", "hello", 5)).toBe(true);
+    expect(w.frames).toEqual(["id: 5\ndata: hello\n\n"]);
+  });
+
+  test("emit to an agent with no sessions returns false", () => {
+    const em = new MessageEmitter();
+    expect(em.emit("ghost", "x", 1)).toBe(false);
+  });
+
+  test("emitToSession targets exactly one session", () => {
+    const em = new MessageEmitter();
+    const w1 = mockWriter(); const w2 = mockWriter();
+    em.register("a", "s1", w1.writer);
+    em.register("a", "s2", w2.writer);
+    em.emitToSession("a", "s2", "only2", 7);
+    expect(w1.frames).toEqual([]);
+    expect(w2.seqs()).toEqual([7]);
+  });
+});
+
+describe("MessageEmitter — replay buffering preserves global seq order", () => {
+  test("live emits during replay buffer, then flush AFTER backlog, in order", () => {
+    const em = new MessageEmitter();
+    const w = mockWriter();
+    em.register("a", "s1", w.writer);
+
+    em.beginReplay("a", "s1");
+    em.replayWrite("a", "s1", "b1", 1);
+    em.replayWrite("a", "s1", "b2", 2);
+
+    // A higher-seq live message arrives mid-replay → must buffer, not deliver.
+    em.emit("a", "live4", 4);
+    expect(w.seqs()).toEqual([1, 2]);
+
+    em.replayWrite("a", "s1", "b3", 3);
+    em.emitToSession("a", "s1", "live5", 5);
+    expect(w.seqs()).toEqual([1, 2, 3]); // live 4,5 still buffered
+
+    em.endReplay("a", "s1");
+    expect(w.seqs()).toEqual([1, 2, 3, 4, 5]); // backlog, then buffered live — in order
+  });
+
+  test("emit returns true while buffering (connected, not offline)", () => {
+    const em = new MessageEmitter();
+    const w = mockWriter();
+    em.register("a", "s1", w.writer);
+    em.beginReplay("a", "s1");
+    expect(em.emit("a", "x", 9)).toBe(true);
+    expect(w.frames).toEqual([]);
+    em.endReplay("a", "s1");
+    expect(w.seqs()).toEqual([9]);
+  });
+
+  test("endReplay with an empty buffer just resumes direct delivery", () => {
+    const em = new MessageEmitter();
+    const w = mockWriter();
+    em.register("a", "s1", w.writer);
+    em.beginReplay("a", "s1");
+    em.replayWrite("a", "s1", "b1", 1);
+    em.endReplay("a", "s1");
+    em.emit("a", "live2", 2);
+    expect(w.seqs()).toEqual([1, 2]);
+  });
+
+  test("only the replaying session buffers; a sibling session delivers live immediately", () => {
+    const em = new MessageEmitter();
+    const wReplay = mockWriter(); const wLive = mockWriter();
+    em.register("ag", "replaying", wReplay.writer);
+    em.register("ag", "live", wLive.writer);
+
+    em.beginReplay("ag", "replaying");
+    em.emit("ag", "msg", 3); // agent-level: buffer for 'replaying', direct for 'live'
+    expect(wReplay.frames).toEqual([]);
+    expect(wLive.seqs()).toEqual([3]);
+
+    em.endReplay("ag", "replaying");
+    expect(wReplay.seqs()).toEqual([3]);
+  });
+});
+
+describe("MessageEmitter — cleanup on mid-replay disconnect", () => {
+  test("unregister mid-replay: replayWrite returns false, endReplay no-ops, no throw", () => {
+    const em = new MessageEmitter();
+    const w = mockWriter();
+    em.register("a", "s1", w.writer);
+    em.beginReplay("a", "s1");
+    expect(em.replayWrite("a", "s1", "b1", 1)).toBe(true);
+    em.unregister("a", "s1");
+    expect(em.replayWrite("a", "s1", "b2", 2)).toBe(false);
+    expect(() => em.endReplay("a", "s1")).not.toThrow();
+    expect(em.isConnected("a")).toBe(false);
+  });
+
+  test("a writer that throws on write is dropped from the registry", () => {
+    const em = new MessageEmitter();
+    let n = 0;
+    const writer = { write: () => { if (++n === 2) throw new Error("closed"); }, close: () => {} };
+    em.register("a", "s1", writer);
+    em.emit("a", "ok", 1);
+    em.emit("a", "boom", 2);
+    expect(em.isConnected("a")).toBe(false);
+  });
+});

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -3,6 +3,16 @@
  *
  * Tracks writers by both agent ID and session ID. Agent-level emit sends
  * to all sessions; session-level emit targets a specific session.
+ *
+ * Replay buffering: while a session is replaying its backlog (Router.replay),
+ * live emits to that session are BUFFERED and flushed — in arrival (= seq)
+ * order — only after the backlog drains. This lets replay yield to the event
+ * loop between chunks (so a large backlog, or a reconnect storm, can't starve
+ * it) WITHOUT a live message interleaving ahead of un-replayed backlog. That
+ * ordering matters because a live message always has a higher seq than any
+ * backlog, the client acks per-event, and the server stores the cursor as
+ * MAX(last_ack_seq): an out-of-order live message would advance the cursor past
+ * still-undelivered backlog, which a mid-replay disconnect would then drop.
  */
 
 export type SSEWriter = {
@@ -10,9 +20,17 @@ export type SSEWriter = {
   close: () => void;
 };
 
+type SessionStream = {
+  writer: SSEWriter;
+  /** True while this session's backlog replay is in flight. */
+  replaying: boolean;
+  /** Live frames received during replay, held until the backlog drains. */
+  buffer: string[];
+};
+
 export class MessageEmitter {
-  // agent_id → Map<session_id, SSEWriter>
-  private streams = new Map<string, Map<string, SSEWriter>>();
+  // agent_id → Map<session_id, SessionStream>
+  private streams = new Map<string, Map<string, SessionStream>>();
 
   register(agentId: string, sessionId: string, writer: SSEWriter): void {
     if (!this.streams.has(agentId)) {
@@ -21,9 +39,9 @@ export class MessageEmitter {
     // Close existing writer for this session (e.g. stale TCP from network drop)
     const existing = this.streams.get(agentId)!.get(sessionId);
     if (existing) {
-      existing.close();
+      existing.writer.close();
     }
-    this.streams.get(agentId)!.set(sessionId, writer);
+    this.streams.get(agentId)!.set(sessionId, { writer, replaying: false, buffer: [] });
   }
 
   unregister(agentId: string, sessionId: string): void {
@@ -38,50 +56,107 @@ export class MessageEmitter {
   closeAndUnregister(agentId: string, sessionId: string): void {
     const sessions = this.streams.get(agentId);
     if (sessions) {
-      const writer = sessions.get(sessionId);
-      if (writer) writer.close();
+      const stream = sessions.get(sessionId);
+      if (stream) stream.writer.close();
       sessions.delete(sessionId);
       if (sessions.size === 0) this.streams.delete(agentId);
     }
   }
 
+  private frame(data: string, seq?: number): string {
+    return seq != null ? `id: ${seq}\ndata: ${data}\n\n` : `data: ${data}\n\n`;
+  }
+
+  /** Deliver a frame to one session now, or buffer it if the session is mid-replay. */
+  private deliver(agentId: string, sessionId: string, stream: SessionStream, frame: string): void {
+    if (stream.replaying) {
+      stream.buffer.push(frame);
+      return;
+    }
+    try {
+      stream.writer.write(frame);
+    } catch {
+      this.unregister(agentId, sessionId);
+    }
+  }
+
   /**
-   * Emit to all sessions for an agent. Returns true if at least one writer received it.
-   * SSE frames include `id:` for Last-Event-ID reconnect support.
+   * Emit to all sessions for an agent. Returns true if at least one session is
+   * registered (the frame is delivered now, or buffered if that session is
+   * mid-replay). SSE frames include `id:` for Last-Event-ID reconnect support.
    */
   emit(agentId: string, data: string, seq?: number): boolean {
     const sessions = this.streams.get(agentId);
     if (!sessions || sessions.size === 0) return false;
-    const frame = seq != null
-      ? `id: ${seq}\ndata: ${data}\n\n`
-      : `data: ${data}\n\n`;
-    for (const [sessionId, writer] of sessions) {
-      try {
-        writer.write(frame);
-      } catch {
-        sessions.delete(sessionId);
-      }
+    const frame = this.frame(data, seq);
+    for (const [sessionId, stream] of sessions) {
+      this.deliver(agentId, sessionId, stream, frame);
     }
     return true;
   }
 
   /**
-   * Emit to a specific session. Returns true if delivered.
+   * Emit to a specific session. Returns true if the session is registered (the
+   * frame is delivered now, or buffered if mid-replay).
    */
   emitToSession(agentId: string, sessionId: string, data: string, seq?: number): boolean {
     const sessions = this.streams.get(agentId);
     if (!sessions) return false;
-    const writer = sessions.get(sessionId);
-    if (!writer) return false;
-    const frame = seq != null
-      ? `id: ${seq}\ndata: ${data}\n\n`
-      : `data: ${data}\n\n`;
+    const stream = sessions.get(sessionId);
+    if (!stream) return false;
+    this.deliver(agentId, sessionId, stream, this.frame(data, seq));
+    return true;
+  }
+
+  /**
+   * Mark a session as replaying — live emits to it buffer until endReplay().
+   * No-op if the session isn't registered.
+   */
+  beginReplay(agentId: string, sessionId: string): void {
+    const stream = this.streams.get(agentId)?.get(sessionId);
+    if (stream) {
+      stream.replaying = true;
+      stream.buffer = [];
+    }
+  }
+
+  /**
+   * Write a backlog frame directly to a replaying session, bypassing the live
+   * buffer (backlog must reach the client before the buffered live tail).
+   * Returns false if the session is gone or the write threw — the caller should
+   * stop replaying.
+   */
+  replayWrite(agentId: string, sessionId: string, data: string, seq?: number): boolean {
+    const stream = this.streams.get(agentId)?.get(sessionId);
+    if (!stream) return false;
     try {
-      writer.write(frame);
+      stream.writer.write(this.frame(data, seq));
       return true;
     } catch {
-      sessions.delete(sessionId);
+      this.unregister(agentId, sessionId);
       return false;
+    }
+  }
+
+  /**
+   * End replay: flush the buffered live frames (in arrival = seq order), then
+   * resume direct delivery. No-op if the session is gone — its buffer is dropped,
+   * which is safe: the client reconnects from its last ack (≤ the last backlog
+   * seq it received), so nothing buffered-but-unsent is lost.
+   */
+  endReplay(agentId: string, sessionId: string): void {
+    const stream = this.streams.get(agentId)?.get(sessionId);
+    if (!stream) return;
+    const buffered = stream.buffer;
+    stream.buffer = [];
+    stream.replaying = false;
+    for (const frame of buffered) {
+      try {
+        stream.writer.write(frame);
+      } catch {
+        this.unregister(agentId, sessionId);
+        return;
+      }
     }
   }
 

--- a/src/router.test.ts
+++ b/src/router.test.ts
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import pino from "pino";
+import { Store } from "./store";
+import { Router } from "./router";
+import { MessageEmitter } from "./emitter";
+
+const log = pino({ level: "silent" });
+let tmpDir: string; let store: Store; let emitter: MessageEmitter; let router: Router;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "wire-router-"));
+  store = new Store(join(tmpDir, "wire.db"));
+  store.upsertAgent({ id: "ag", display_name: "ag", pubkey: "pk", permanent: true });
+  emitter = new MessageEmitter();
+  router = new Router(store, emitter, log);
+});
+afterEach(() => { try { rmSync(tmpDir, { recursive: true, force: true }); } catch {} });
+
+function mockWriter() {
+  const frames: string[] = [];
+  return {
+    frames,
+    writer: { write: (d: string) => { frames.push(d); }, close: () => {} },
+    seqs: () =>
+      frames
+        .map((f) => { const m = f.match(/^id: (\d+)/); return m ? Number(m[1]) : null; })
+        .filter((s): s is number => s != null),
+  };
+}
+
+describe("Router.replay — chunked async backlog", () => {
+  test("delivers all backlog for the session, in seq order, across chunk boundaries", async () => {
+    // 120 backlog messages (> CHUNK=50 → multiple chunks) before any session.
+    for (let i = 0; i < 120; i++) {
+      router.route({ source: "x", dest: "ag", topic: "t", payload: JSON.stringify({ n: i }) });
+    }
+    const sess = store.createSession("ag");
+    const w = mockWriter();
+    emitter.register("ag", sess.id, w.writer);
+
+    await router.replay("ag", sess.id);
+
+    expect(w.seqs()).toEqual(Array.from({ length: 120 }, (_, i) => i + 1));
+  });
+
+  test("a live message arriving mid-replay is delivered AFTER the full backlog", async () => {
+    for (let i = 0; i < 60; i++) {
+      router.route({ source: "x", dest: "ag", topic: "t", payload: JSON.stringify({ n: i }) });
+    }
+    const sess = store.createSession("ag");
+    const w = mockWriter();
+    emitter.register("ag", sess.id, w.writer);
+
+    const p = router.replay("ag", sess.id);            // sync prefix runs first chunk, then yields
+    emitter.emit("ag", JSON.stringify({ live: true }), 9999); // replaying → buffered
+    await p;                                            // drains remaining chunks, then flushes buffer
+
+    const seqs = w.seqs();
+    expect(seqs.length).toBe(61);
+    expect(seqs.slice(0, 60)).toEqual(Array.from({ length: 60 }, (_, i) => i + 1));
+    expect(seqs[60]).toBe(9999); // live delivered last, never ahead of backlog
+  });
+
+  test("replay with no backlog completes and resumes live delivery", async () => {
+    const sess = store.createSession("ag");
+    const w = mockWriter();
+    emitter.register("ag", sess.id, w.writer);
+    await router.replay("ag", sess.id);
+    emitter.emit("ag", "x", 5);
+    expect(w.seqs()).toEqual([5]);
+  });
+});

--- a/src/router.ts
+++ b/src/router.ts
@@ -216,26 +216,48 @@ export class Router {
   }
 
   /**
-   * Replay backlog for a session. Sends all messages addressed to this agent
-   * (unicast or broadcast) since their last ack.
+   * Replay backlog for a session, then resume live delivery. Runs async and
+   * CHUNKED: emits the backlog in batches, yielding to the event loop between
+   * them, so a large backlog (or many simultaneous reconnects) can't starve it —
+   * the synchronous-replay burst was the load that turned an SSE flap into a
+   * gateway hang.
+   *
+   * Live messages that arrive mid-replay are buffered by the emitter
+   * (beginReplay/endReplay) and flushed, in seq order, once the backlog drains —
+   * so the client never sees a higher-seq live message ahead of un-replayed
+   * backlog (which, with MAX(last_ack_seq) + per-event acks, would strand the
+   * skipped backlog on a mid-replay disconnect). Targets the specific session,
+   * not every session of the agent.
    */
-  replay(agentId: string, sessionId: string): void {
+  async replay(agentId: string, sessionId: string): Promise<void> {
     const session = this.store.getSession(sessionId);
     if (!session) return;
 
-    const messages = this.store.getMessagesForAgent(agentId, session.last_ack_seq, 1000);
-
-    for (const msg of messages) {
-      const data = JSON.stringify({
-        seq: msg.seq,
-        source: msg.source,
-        topic: msg.topic,
-        payload: JSON.parse(msg.payload),
-        dest: msg.dest,
-        created_at: msg.created_at,
-      });
-
-      this.emitter.emit(agentId, data, msg.seq);
+    this.emitter.beginReplay(agentId, sessionId);
+    try {
+      const messages = this.store.getMessagesForAgent(agentId, session.last_ack_seq, 1000);
+      const CHUNK = 50;
+      for (let i = 0; i < messages.length; i++) {
+        const msg = messages[i];
+        const data = JSON.stringify({
+          seq: msg.seq,
+          source: msg.source,
+          topic: msg.topic,
+          payload: JSON.parse(msg.payload),
+          dest: msg.dest,
+          created_at: msg.created_at,
+        });
+        if (!this.emitter.replayWrite(agentId, sessionId, data, msg.seq)) {
+          return; // session gone mid-replay — endReplay() (finally) no-ops
+        }
+        if ((i + 1) % CHUNK === 0) {
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
+        }
+      }
+    } finally {
+      // Always flush buffered live frames and resume direct delivery, even if a
+      // write failed or the backlog was empty.
+      this.emitter.endReplay(agentId, sessionId);
     }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -686,7 +686,13 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
           const session = store.getSession(sessionId!);
           const replaySeq = session?.last_ack_seq ?? 0;
           log.info({ event: "sse_replay", agentId, sessionId, fromSeq: replaySeq }, "SSE replaying backlog");
-          router.replay(agentId, sessionId!);
+          // Fire-and-forget: replay is chunked/async so it doesn't block the
+          // stream handler (or the event loop). Live emits to this session
+          // buffer until the backlog drains. beginReplay runs synchronously
+          // here, before the first live message can arrive.
+          router.replay(agentId, sessionId!).catch((e) => {
+            log.error({ event: "sse_replay_error", agentId, sessionId, err: String(e) }, "SSE backlog replay failed");
+          });
 
           c.req.raw.signal.addEventListener("abort", () => {
             log.info({ event: "sse_abort", agentId, sessionId }, "SSE client disconnected");


### PR DESCRIPTION
Closes the root cause of the 2026-06-05 gateway hang (open-thread #3). Tim approved fix+deploy.

## Cause
The synchronous-replay burst was the load that turned an SSE flap into a hang. On each reconnect the stream handler re-emitted the **whole backlog in one tick**; a reconnect storm ran many of those back-to-back until the event loop starved (`/health` timing out). The already-deployed reap hysteresis stops the *trigger*; this removes the *amplifier*.

## Why it couldn't be a naive chunk
A live message always has a higher seq than any backlog, the client acks **per-event**, and the server stores the cursor as `MAX(last_ack_seq)`. So a live message interleaving a chunked replay would advance the cursor past still-undelivered backlog → a mid-replay disconnect (the flap scenario) would **drop** it.

## Fix — buffer-during-replay (emitter)
- Per-session replay state: `beginReplay()` buffers live emits; `replayWrite()` streams backlog directly; `endReplay()` flushes the buffer in seq order and resumes direct delivery. **Steady-state (non-replay) delivery is unchanged** — buffering only activates during the per-reconnect replay window.
- `router.replay()` is now async + chunked (50/batch, yielding between), and targets the **specific** session instead of re-emitting to every session of the agent (a latent duplicate-delivery quirk). Fire-and-forget from the stream handler; `beginReplay` runs synchronously before the first live message can arrive.

## Ordering guarantee (tested)
Backlog drains first; buffered live flushes after → strictly increasing seq, so the cursor never skips undelivered backlog even on a mid-replay disconnect.

## Tests — 45/45
- `emitter.test.ts` (9): buffer/flush order, `emit` returns true while buffering (connected≠offline), sibling-session isolation, mid-replay disconnect cleanup, writer-throw eviction.
- `router.test.ts` (3): chunk-boundary full in-order delivery (120 msgs), live-during-replay delivered last (real router path), empty-backlog completion.

Pairs with deployed reap hysteresis + keepalive hardening (#28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)