### PR TITLE
plugin_settings mutation events: scope to the namespace owner

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -209,3 +209,60 @@ describe("inbound webhook — ack_early (immediate-ACK + race-safe dedup)", () =
     expect(Array.isArray(json.delivered_to)).toBe(true);
   });
 });
+
+describe("plugin_settings mutation events — scoped to the namespace owner, not broadcast", () => {
+  function rawDb() {
+    return (store as unknown as {
+      db: { prepare: (q: string) => { get: (...a: unknown[]) => unknown } };
+    }).db;
+  }
+
+  function putSetting(namespace: string, key: string, value: unknown) {
+    return fetch(`${baseUrl}/plugin_settings/${namespace}/${encodeURIComponent(key)}?token=${TOKEN}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value }),
+    });
+  }
+
+  test("PUT routes the updated event dest=namespace; bystanders get no delivery", async () => {
+    store.upsertAgent({ id: "vaultns", display_name: "vaultns", pubkey: "pk-v" });
+    // beforeEach registered "fondant" — the bystander a broadcast would have reached.
+
+    const res = await putSetting("vaultns", "wallet:0xabc", { name: "w" });
+    expect(res.status).toBe(200);
+
+    const msg = store.getMessages(0, 1000).filter((m) => m.topic === "plugin_settings.updated").pop();
+    expect(msg?.dest).toBe("vaultns");
+
+    const bystander = rawDb().prepare(
+      "SELECT count(*) AS n FROM delivery_log dl JOIN messages m ON m.seq = dl.message_seq WHERE m.topic = 'plugin_settings.updated' AND dl.agent_id = 'fondant'",
+    ).get() as { n: number };
+    expect(bystander.n).toBe(0);
+  });
+
+  test("DELETE routes the deleted event dest=namespace", async () => {
+    store.upsertAgent({ id: "vaultns", display_name: "vaultns", pubkey: "pk-v" });
+    await putSetting("vaultns", "k", 1);
+
+    const res = await fetch(`${baseUrl}/plugin_settings/vaultns/k?token=${TOKEN}`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+
+    const msg = store.getMessages(0, 1000).filter((m) => m.topic === "plugin_settings.deleted").pop();
+    expect(msg?.dest).toBe("vaultns");
+  });
+
+  test("ownerless namespace (operator-only) routes without error and floods nobody", async () => {
+    // No agent registered with this id — delivery is a logged no-op, never a throw.
+    const res = await putSetting("fv-throwaway", "k", { x: 1 });
+    expect(res.status).toBe(200);
+
+    const msg = store.getMessages(0, 1000).filter((m) => m.topic === "plugin_settings.updated").pop();
+    expect(msg?.dest).toBe("fv-throwaway");
+
+    const anyDelivery = rawDb().prepare(
+      "SELECT count(*) AS n FROM delivery_log dl JOIN messages m ON m.seq = dl.message_seq WHERE m.topic = 'plugin_settings.updated' AND dl.result = 'ok'",
+    ).get() as { n: number };
+    expect(anyDelivery.n).toBe(0);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1245,11 +1245,18 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
 
     store.setPluginSetting(namespace, key, value, writer);
 
-    // Notify subscribers. Broadcast (no dest) so any agent or integration
-    // that subscribes to "plugin_settings.updated" gets the live mutation.
+    // Notify the namespace owner — scoped (dest=namespace), not broadcast.
+    // The write-auth model above already makes a namespace the property of
+    // the identity whose id matches it, and that identity is the consumer
+    // that needs live mutations (e.g. an integration watching its own
+    // directory). A broadcast fanned every namespace's churn into every
+    // agent's context. Server-side consumers (dashboard) still see all
+    // mutations via route listeners, which fire regardless of dest; anyone
+    // else can poll the public GET.
     router.route({
       source: "wire",
       topic: "plugin_settings.updated",
+      dest: namespace,
       payload: JSON.stringify({ namespace, key, value, updated_by: writer, updated_at: Date.now() }),
     });
 
@@ -1277,9 +1284,11 @@ export function createServer({ port, store, router, emitter, log, heartbeats, on
 
     const removed = store.deletePluginSetting(namespace, key);
     if (removed) {
+      // Scoped to the namespace owner — same rationale as the PUT event.
       router.route({
         source: "wire",
         topic: "plugin_settings.deleted",
+        dest: namespace,
         payload: JSON.stringify({ namespace, key, deleted_by: writer, deleted_at: Date.now() }),
       });
     }


### PR DESCRIPTION
## Why

`plugin_settings.updated`/`.deleted` route with no `dest` — a broadcast to **every registered identity**. Any namespace churn lands in every agent's context. Concretely today: a wallet-vault harness's directory writes flooded uninvolved agents' inboxes (florentine et al.) with `wallet:0x…` events all morning (Brioche-relayed; observed live).

## What

Route mutations with `dest: namespace`. Generic — no plugin-named code:

- The write-auth model already makes a namespace the property of the identity whose id matches it (PUT/DELETE require operator or `agent.id === namespace`). That identity is the consumer that needs live mutations (e.g. an integration watching its own directory).
- **Dashboard unaffected**: route listeners fire regardless of dest.
- Anyone else can poll the public `GET /plugin_settings/:ns`.
- Ownerless namespaces (operator-only writes, e.g. FV throwaways) deliver as a logged no-op (`skipped_offline`) — verified no-throw.

## Tests

3 new (scoped PUT, scoped DELETE, ownerless no-op + nobody-delivered). Full suite 48/48.

## Deploy note

Gateway restart replays backlogs to reconnecting agents — canele-2947's ENG-3313 harness is mid-flight, so deploy should ride a quiet window (e.g. the wallet-extension v0.4.0 rollout moment) rather than land immediately. Existing broadcast backlog entries still replay post-deploy; they age out per retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)